### PR TITLE
refactor(WebWorkers): Use webworker-promise instead of promise-worker…

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "mime-types": "^2.1.15",
     "promise-file-reader": "^0.3.1",
-    "promise-worker-transferable": "^1.0.4"
+    "webworker-promise": "^0.4.1"
   },
   "standard": {
     "ignore": [

--- a/src/readImageArrayBuffer.js
+++ b/src/readImageArrayBuffer.js
@@ -1,9 +1,9 @@
-const PromiseWorker = require('promise-worker-transferable')
+const WebworkerPromise = require('webworker-promise')
 
 const config = require('./itkConfig.js')
 
 const worker = new window.Worker(config.webWorkersPath + '/ImageIOWorker.js')
-const promiseWorker = new PromiseWorker(worker)
+const promiseWorker = new WebworkerPromise(worker)
 
 /**
  * Read an image from a file ArrayBuffer in the browser.

--- a/src/readImageBlob.js
+++ b/src/readImageBlob.js
@@ -1,10 +1,10 @@
-const PromiseWorker = require('promise-worker-transferable')
+const WebworkerPromise = require('webworker-promise')
 const PromiseFileReader = require('promise-file-reader')
 
 const config = require('./itkConfig.js')
 
 const worker = new window.Worker(config.webWorkersPath + '/ImageIOWorker.js')
-const promiseWorker = new PromiseWorker(worker)
+const promiseWorker = new WebworkerPromise(worker)
 
 /**
  * @param: blob Blob that contains the file contents

--- a/src/readImageDICOMFileSeries.js
+++ b/src/readImageDICOMFileSeries.js
@@ -1,10 +1,10 @@
-const PromiseWorker = require('promise-worker-transferable')
+const WebworkerPromise = require('webworker-promise')
 const PromiseFileReader = require('promise-file-reader')
 
 const config = require('./itkConfig.js')
 
 const worker = new window.Worker(config.webWorkersPath + '/ImageIOWorker.js')
-const promiseWorker = new PromiseWorker(worker)
+const promiseWorker = new WebworkerPromise(worker)
 
 const readImageDICOMFileSeries = (fileList) => {
   const fetchFileDescriptions = Array.from(fileList, function (file) {

--- a/src/readImageFile.js
+++ b/src/readImageFile.js
@@ -1,10 +1,10 @@
-const PromiseWorker = require('promise-worker-transferable')
+const WebworkerPromise = require('webworker-promise')
 const PromiseFileReader = require('promise-file-reader')
 
 const config = require('./itkConfig.js')
 
 const worker = new window.Worker(config.webWorkersPath + '/ImageIOWorker.js')
-const promiseWorker = new PromiseWorker(worker)
+const promiseWorker = new WebworkerPromise(worker)
 
 const readImageFile = (file) => {
   return PromiseFileReader.readAsArrayBuffer(file)

--- a/src/writeImageArrayBuffer.js
+++ b/src/writeImageArrayBuffer.js
@@ -1,9 +1,9 @@
-const PromiseWorker = require('promise-worker-transferable')
+const WebworkerPromise = require('webworker-promise')
 
 const config = require('./itkConfig.js')
 
 const worker = new window.Worker(config.webWorkersPath + '/ImageIOWorker.js')
-const promiseWorker = new PromiseWorker(worker)
+const promiseWorker = new WebworkerPromise(worker)
 
 /**
  * Write a file ArrayBuffer from an image in the browser.


### PR DESCRIPTION
…-transferable

More capable and better maintained.

CC: @agirault 