### PR TITLE
ci(CircleCI): Specify filters in the workflow configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,6 @@ version: 2
 jobs:
   build-test-deploy:
     machine: true
-    branches:
-      ignore:
-        - gh-pages
     steps:
       - checkout
       - run:
@@ -44,9 +41,6 @@ jobs:
   build-test-examples:
     docker:
       - image: node:latest
-    branches:
-      ignore:
-        - gh-pages
     steps:
       - checkout
       - run:
@@ -61,7 +55,15 @@ workflows:
     version: 2
     build-test-deploy:
       jobs:
-        - build-test-deploy
+        - build-test-deploy:
+            filters:
+              branches:
+                ignore:
+                  - gh-pages
     build-test-examples:
       jobs:
-        - build-test-deploy
+        - build-test-deploy:
+            filters:
+              branches:
+                ignore:
+                  - gh-pages


### PR DESCRIPTION
With workflows, the filters must be in the workflow configuration instead of the job configuration.