### PR TITLE
feat(BrowserAPI): Return and accept the web worker used for computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,18 @@ itk.js
 
 [![CircleCI](https://img.shields.io/circleci/project/github/InsightSoftwareConsortium/itk-js/master.svg)](https://circleci.com/gh/InsightSoftwareConsortium/itk-js)
 
-Provides general scientific image, mesh, and point set IO capability and bridges
-[ITK](https://itk.org) code running in an
-[asm.js](http://asmjs.org/) or [WebAssembly](http://webassembly.org/)
-runtime environment.
+*itk.js* combines [Emscripten](http://emscripten.org/) and
+[ITK](https://www.itk.org/) to enable high-performance spatial analysis in a
+JavaScript runtime environment.
+
+The project provides tools to a) build C/C++ code to JavaScript
+([asm.js](http://asmjs.org/)) and [WebAssembly](http://webassembly.org/), b)
+bridge local filesystems, native JavaScript data structures, and traditional
+file formats, c) transfer data efficiently in and out of the Emscripten
+runtime, and d) asynchronously execute processing pipelines in a background
+thread. *itk.js* can be used to execute [ITK](https://www.itk.org/),
+[VTK](https://www.vtk.org/) or arbitrary C++ codes in the browser or on a
+workstation / server with Node.js.
 
 For more information, please see [the project
 documentation](https://insightsoftwareconsortium.github.io/itk-js/).

--- a/doc/content/api/browser.md
+++ b/doc/content/api/browser.md
@@ -7,24 +7,26 @@ The *itk.js* IO functions convert native brower objects, [File](https://develope
 
 Most of these functions return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
+These functions return the [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) used for computation. They also optionally accept a web worker from a previous execution as their first argument -- pass the worker generated from execution or `null` if one is not available.
 
-## readImageFile(file) -> [itk/Image](./Image.html)
+
+## readImageFile(webWorker, file) -> { webWorker, [itk/Image](./Image.html) }
 
 Read an image from a [File](https://developer.mozilla.org/en-US/docs/Web/API/File).
 
-## readImageBlob(blob, fileName, mimeType) -> [itk/Image](./Image.html)
+## readImageBlob(webWorker, blob, fileName, mimeType) -> { webWorker, [itk/Image](./Image.html) }
 
 Read an image from a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob). `fileName` is a string with the file name. `mimeType` is an optional mime-type string.
 
-## readImageArrayBuffer(arrayBuffer, fileName, mimeType) -> [itk/Image](./Image.html)
+## readImageArrayBuffer(webWorker, arrayBuffer, fileName, mimeType) -> { webWorker, [itk/Image](./Image.html) }
 
 Read an image from an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). `fileName` is a string with the file name. `mimeType` is an optional mime-type string.
 
-## readImageDICOMFileSeries(fileList) -> [itk/Image](./Image.html)
+## readImageDICOMFileSeries(webWorker, fileList) -> { webWorker, [itk/Image](./Image.html) }
 
 Read an image from a series of DICOM [File](https://developer.mozilla.org/en-US/docs/Web/API/File)'s stored in an [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) or [FileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList).
 
-## writeImageArrayBuffer(useCompression, image, fileName, mimeType) -> [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)
+## writeImageArrayBuffer(webWorker, useCompression, image, fileName, mimeType) ->  { webWorker, [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) }
 
 Write an image to a an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 

--- a/examples/Webpack/src/index.js
+++ b/examples/Webpack/src/index.js
@@ -4,7 +4,7 @@ import curry from 'curry'
 const outputFileInformation = curry(function outputFileInformation (outputTextArea, event) {
   const dataTransfer = event.dataTransfer
   const files = event.target.files || dataTransfer.files
-  return readImageFile(files[0])
+  return readImageFile(null, files[0])
     .then(function (image) {
       function replacer (key, value) {
         if (!!value && value.byteLength !== undefined) {

--- a/src/Docker/itk-js/Dockerfile
+++ b/src/Docker/itk-js/Dockerfile
@@ -18,7 +18,7 @@ RUN cd / && \
   find . -name '*.o' -delete && \
   cd .. && chmod -R 777 ITKBridgeJavaScript-build
 
-COPY ITKBridgeJavaScript.cmake /usr/share/cmake-3.10/Modules/
+COPY ITKBridgeJavaScript.cmake /usr/share/cmake-3.11/Modules/
 COPY web-build /usr/local/bin/
 
 ENV DEFAULT_DOCKCROSS_IMAGE insighttoolkit/itk-js

--- a/src/readImageFile.js
+++ b/src/readImageFile.js
@@ -3,24 +3,30 @@ import PromiseFileReader from 'promise-file-reader'
 
 import config from './itkConfig'
 
-const worker = new window.Worker(
-  config.itkModulesPath + '/WebWorkers/ImageIO.worker.js'
-)
-const promiseWorker = new WebworkerPromise(worker)
-
-const readImageFile = (file) => {
-  return PromiseFileReader.readAsArrayBuffer(file).then((arrayBuffer) => {
-    return promiseWorker.postMessage(
-      {
-        operation: 'readImage',
-        name: file.name,
-        type: file.type,
-        data: arrayBuffer,
-        config: config
-      },
-      [arrayBuffer]
+const readImageFile = (webWorker, file) => {
+  let worker = webWorker
+  if (!worker) {
+    worker = new window.Worker(
+      config.itkModulesPath + '/WebWorkers/ImageIO.worker.js'
     )
-  })
+  }
+  const promiseWorker = new WebworkerPromise(worker)
+  return PromiseFileReader.readAsArrayBuffer(file)
+    .then((arrayBuffer) => {
+      return promiseWorker.postMessage(
+        {
+          operation: 'readImage',
+          name: file.name,
+          type: file.type,
+          data: arrayBuffer,
+          config: config
+        },
+        [arrayBuffer]
+      )
+    }
+    ).then(function (image) {
+      return Promise.resolve({ image, webWorker: worker })
+    })
 }
 
 export default readImageFile

--- a/src/readMeshArrayBuffer.js
+++ b/src/readMeshArrayBuffer.js
@@ -2,10 +2,14 @@ import WebworkerPromise from 'webworker-promise'
 
 import config from './itkConfig'
 
-const worker = new window.Worker(config.itkModulesPath + '/WebWorkers/MeshIO.worker.js')
-const promiseWorker = new WebworkerPromise(worker)
-
-const readMeshArrayBuffer = (arrayBuffer, fileName, mimeType) => {
+const readMeshArrayBuffer = (webWorker, arrayBuffer, fileName, mimeType) => {
+  let worker = webWorker
+  if (!worker) {
+    worker = new window.Worker(
+      config.itkModulesPath + '/WebWorkers/MeshIO.worker.js'
+    )
+  }
+  const promiseWorker = new WebworkerPromise(worker)
   return promiseWorker.postMessage(
     {
       operation: 'readMesh',
@@ -14,7 +18,10 @@ const readMeshArrayBuffer = (arrayBuffer, fileName, mimeType) => {
       data: arrayBuffer,
       config
     },
-    [arrayBuffer])
+    [arrayBuffer]
+  ).then(function (mesh) {
+    return Promise.resolve({ mesh, webWorker: worker })
+  })
 }
 
 export default readMeshArrayBuffer

--- a/src/readMeshBlob.js
+++ b/src/readMeshBlob.js
@@ -3,14 +3,21 @@ import PromiseFileReader from 'promise-file-reader'
 
 import config from './itkConfig'
 
-const worker = new window.Worker(config.itkModulesPath + '/WebWorkers/MeshIO.worker.js')
-const promiseWorker = new WebworkerPromise(worker)
-
-const readMeshBlob = (blob, fileName, mimeType) => {
+const readMeshBlob = (webWorker, blob, fileName, mimeType) => {
+  let worker = webWorker
+  if (!worker) {
+    worker = new window.Worker(
+      config.itkModulesPath + '/WebWorkers/MeshIO.worker.js'
+    )
+  }
+  const promiseWorker = new WebworkerPromise(worker)
   return PromiseFileReader.readAsArrayBuffer(blob)
     .then(arrayBuffer => {
       return promiseWorker.postMessage({ operation: 'readMesh', name: fileName, type: mimeType, data: arrayBuffer, config: config },
         [arrayBuffer])
+    }
+    ).then(function (mesh) {
+      return Promise.resolve({ mesh, webWorker: worker })
     })
 }
 

--- a/src/readMeshFile.js
+++ b/src/readMeshFile.js
@@ -3,10 +3,14 @@ import PromiseFileReader from 'promise-file-reader'
 
 import config from './itkConfig'
 
-const worker = new window.Worker(config.itkModulesPath + '/WebWorkers/MeshIO.worker.js')
-const promiseWorker = new WebworkerPromise(worker)
-
-const readMeshFile = (file) => {
+const readMeshFile = (webWorker, file) => {
+  let worker = webWorker
+  if (!worker) {
+    worker = new window.Worker(
+      config.itkModulesPath + '/WebWorkers/MeshIO.worker.js'
+    )
+  }
+  const promiseWorker = new WebworkerPromise(worker)
   return PromiseFileReader.readAsArrayBuffer(file)
     .then(arrayBuffer => {
       return promiseWorker.postMessage(
@@ -18,6 +22,9 @@ const readMeshFile = (file) => {
           config: config
         },
         [arrayBuffer])
+    }
+    ).then(function (mesh) {
+      return Promise.resolve({ mesh, webWorker: worker })
     })
 }
 

--- a/src/writeMeshArrayBuffer.js
+++ b/src/writeMeshArrayBuffer.js
@@ -2,10 +2,14 @@ import WebworkerPromise from 'webworker-promise'
 
 import config from './itkConfig'
 
-const worker = new window.Worker(config.itkModulesPath + '/WebWorkers/MeshIO.worker.js')
-const promiseWorker = new WebworkerPromise(worker)
-
-const writeMeshArrayBuffer = ({ useCompression, binaryFileType }, mesh, fileName, mimeType) => {
+const writeMeshArrayBuffer = (webWorker, { useCompression, binaryFileType }, mesh, fileName, mimeType) => {
+  let worker = webWorker
+  if (!worker) {
+    worker = new window.Worker(
+      config.itkModulesPath + '/WebWorkers/MeshIO.worker.js'
+    )
+  }
+  const promiseWorker = new WebworkerPromise(worker)
   const transferables = []
   if (mesh.points.buffer) {
     transferables.push(mesh.points.buffer)
@@ -38,7 +42,9 @@ const writeMeshArrayBuffer = ({ useCompression, binaryFileType }, mesh, fileName
       config
     },
     transferables
-  )
+  ).then(function () {
+    return Promise.resolve({ webWorker: worker })
+  })
 }
 
 export default writeMeshArrayBuffer

--- a/test/Browser/DICOMSeriesTest.js
+++ b/test/Browser/DICOMSeriesTest.js
@@ -20,9 +20,9 @@ test('Test reading DICOM file series', t => {
 
   return Promise.all(fetchFiles)
     .then(function (files) {
-      return readImageDICOMFileSeries(files)
+      return readImageDICOMFileSeries(null, files)
     })
-    .then(function (image) {
+    .then(function ({ image }) {
       t.is(image.imageType.dimension, 3, 'dimension')
       t.is(image.imageType.componentType, IntTypes.UInt8, 'componentType')
       t.is(image.imageType.pixelType, PixelTypes.Scalar, 'pixelType')

--- a/test/Browser/readImageTest.js
+++ b/test/Browser/readImageTest.js
@@ -44,35 +44,50 @@ const verifyImage = (t, image) => {
 test('readImageArrayBuffer reads an ArrayBuffer', (t) => {
   return PromiseFileReader.readAsArrayBuffer(cthead1SmallFile)
     .then(arrayBuffer => {
-      return readImageArrayBuffer(arrayBuffer, 'cthead1Small.png').then(function (image) {
-        verifyImage(t, image)
-      })
+      return readImageArrayBuffer(null, arrayBuffer, 'cthead1Small.png')
+        .then(function ({ image, webWorker }) {
+          webWorker.terminate()
+          verifyImage(t, image)
+        })
     })
 })
 
 test('readImageBlob reads a Blob', (t) => {
-  return readImageBlob(cthead1SmallBlob, 'cthead1Small.png').then(function (image) {
-    verifyImage(t, image)
-  })
+  return readImageBlob(null, cthead1SmallBlob, 'cthead1Small.png')
+    .then(function ({ image }) {
+      verifyImage(t, image)
+    })
 })
 
 test('readImageBlob reads a Blob without a file extension', (t) => {
-  return readImageBlob(cthead1SmallBlob1, 'cthead1Small').then(function (image) {
-    verifyImage(t, image)
-  })
+  return readImageBlob(null, cthead1SmallBlob1, 'cthead1Small')
+    .then(function ({ image }) {
+      verifyImage(t, image)
+    })
 })
 
 test('readImageFile reads a File', (t) => {
-  return readImageFile(cthead1SmallFile).then(function (image) {
-    verifyImage(t, image)
-  })
+  return readImageFile(null, cthead1SmallFile)
+    .then(function ({ image }) {
+      verifyImage(t, image)
+    })
+})
+
+test('readImageFile re-uses a WebWorker', (t) => {
+  return readImageFile(null, cthead1SmallFile)
+    .then(function ({ image, webWorker }) {
+      return readImageFile(webWorker, cthead1SmallFile)
+        .then(function ({ image }) {
+          verifyImage(t, image)
+        })
+    })
 })
 
 test('readImageFile throws a catchable error for an invalid file', (t) => {
   const invalidArray = new Uint8Array([21, 4, 4, 4, 4, 9, 5, 0, 82, 42])
   const invalidBlob = new window.Blob([invalidArray])
   const invalidFile = new window.File([invalidBlob], 'invalid.file')
-  return readImageFile(invalidFile).then(function (image) {
+  return readImageFile(null, invalidFile).then(function ({ image }) {
     t.fail('should not have successfully read the image')
     t.end()
   }).catch(function (error) {

--- a/test/Browser/writeImageTest.js
+++ b/test/Browser/writeImageTest.js
@@ -39,16 +39,16 @@ const verifyImage = (t, image) => {
   t.end()
 }
 
-test('writeImageArrayBuffer writes to an ArrayBuffer', t => {
+test('writeImageArrayBuffer writes to an ArrayBuffer', (t) => {
   return PromiseFileReader.readAsArrayBuffer(cthead1SmallFile)
-    .then(arrayBuffer => {
-      return readImageArrayBuffer(arrayBuffer, 'cthead1Small.png').then(function (image) {
+    .then((arrayBuffer) => {
+      return readImageArrayBuffer(null, arrayBuffer, 'cthead1Small.png').then(function ({ image }) {
         const useCompression = false
-        return writeImageArrayBuffer(useCompression, image, 'cthead1Small.png')
+        return writeImageArrayBuffer(null, useCompression, image, 'cthead1Small.png')
       })
     })
     .then(function (writtenArrayBuffer) {
-      return readImageArrayBuffer(writtenArrayBuffer, 'cthead1Small.png').then(function (image) {
+      return readImageArrayBuffer(null, writtenArrayBuffer, 'cthead1Small.png').then(function ({ image }) {
         verifyImage(t, image)
       })
     })

--- a/test/Browser/writeMeshTest.js
+++ b/test/Browser/writeMeshTest.js
@@ -24,13 +24,13 @@ const verifyMesh = (t, mesh) => {
 test('writeMeshArrayBuffer writes to an ArrayBuffer', t => {
   return axios.get(testFilePath, {responseType: 'arraybuffer'})
     .then(function (response) {
-      return readMeshArrayBuffer(response.data, 'cow.vtk').then(function (mesh) {
+      return readMeshArrayBuffer(null, response.data, 'cow.vtk').then(function (mesh) {
         const useCompression = false
-        return writeMeshArrayBuffer(useCompression, mesh, 'cow.vtk')
+        return writeMeshArrayBuffer(null, useCompression, mesh, 'cow.vtk')
       })
     })
     .then(function (writtenArrayBuffer) {
-      return readMeshArrayBuffer(writtenArrayBuffer, 'cow.vtk').then(function (mesh) {
+      return readMeshArrayBuffer(null, writtenArrayBuffer, 'cow.vtk').then(function (mesh) {
         verifyMesh(t, mesh)
       })
     })


### PR DESCRIPTION
This enables re-use of the web worker or calling `terminate()` on the worker to free resources. We
also fix a bug -- previously only a single worker was being used by the
app.

BREAKING CHANGE: Calls to the browser API must now pass null or a previously generated web worker as
their first argument. The browser API function now return objects with a `webWorker` member.