### PR TITLE
feat(Pipelines): Add MeshToPolyData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ test/StdoutStderrPipeline/web-build/
 test/InputOutputFilesPipeline/web-build/
 test/MeshReadWritePipeline/web-build/
 test/WriteVTKPolyDataPipeline/web-build/
+src/Pipelines/MeshToPolyData/web-build/

--- a/build.js
+++ b/build.js
@@ -238,7 +238,8 @@ if (program.buildPipelines) {
     path.join(__dirname, 'test', 'MedianFilterPipeline'),
     path.join(__dirname, 'test', 'InputOutputFilesPipeline'),
     path.join(__dirname, 'test', 'MeshReadWritePipeline'),
-    path.join(__dirname, 'test', 'WriteVTKPolyDataPipeline')
+    path.join(__dirname, 'test', 'WriteVTKPolyDataPipeline'),
+    path.join(__dirname, 'src', 'Pipelines', 'MeshToPolyData'),
   ]
   try {
     fs.mkdirSync(path.join(__dirname, 'dist', 'Pipelines'))

--- a/src/Docker/itk-js-vtk/Dockerfile
+++ b/src/Docker/itk-js-vtk/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Insight Software Consortium <community@itk.org>
 WORKDIR /
 
 # 2019-01-03 + Emscripten patches
-ENV VTK_GIT_TAG 75fa8e53cca78679db6cc0033f1d7dbe70163b8d
+ENV VTK_GIT_TAG 519acbcfba80c6e3861a2254781371cd4dfc78fb
 RUN git clone https://github.com/thewtex/VTK.git && \
   cd VTK && \
   git checkout ${VTK_GIT_TAG} && \
@@ -19,7 +19,8 @@ RUN git clone https://github.com/thewtex/VTK.git && \
     -DCMAKE_INSTALL_PREFIX:PATH=/install-prefix \
     -DBUILD_EXAMPLES:BOOL=OFF \
     -DBUILD_TESTING:BOOL=OFF \
-    -DVTK_RENDERING_BACKEND:STRING=OpenGL2 \
+    -DVTK_RENDERING_BACKEND:STRING=None \
+    -DModule_vtkIOExport:BOOL=ON \
     -DVTK_NO_PLATFORM_SOCKETS:BOOL=ON \
     ../VTK && \
   ninja -j7 && \

--- a/src/Pipelines/MeshToPolyData/CMakeLists.txt
+++ b/src/Pipelines/MeshToPolyData/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.10)
+project(MeshToPolyData)
+
+find_package(VTK REQUIRED
+  COMPONENTS
+    vtkIOExport
+    vtkFiltersGeometry
+  )
+include(${VTK_USE_FILE})
+
+set(io_components ITKMeshIO)
+if(EMSCRIPTEN)
+  set(io_components BridgeJavaScript)
+endif()
+find_package(ITK REQUIRED
+  COMPONENTS
+    ITKIOMeshBase
+    ITKVtkGlue
+    ${io_components}
+  )
+include(${ITK_USE_FILE})
+
+if(EMSCRIPTEN)
+  include(ITKBridgeJavaScript)
+  web_add_executable(MeshToPolyData MeshToPolyData.cxx)
+  web_target_link_libraries(MeshToPolyData ${VTK_LIBRARIES} ${ITK_LIBRARIES})
+else()
+  add_executable(MeshToPolyData MeshToPolyData.cxx)
+  target_link_libraries(MeshToPolyData ${VTK_LIBRARIES} ${ITK_LIBRARIES})
+endif()
+
+enable_testing()
+add_test(NAME MeshToPolyData
+  COMMAND MeshToPolyData ${CMAKE_CURRENT_BINARY_DIR}/cow.vtk
+  ${CMAKE_CURRENT_BINARY_DIR}/cow.written.vtk.json
+  )

--- a/src/Pipelines/MeshToPolyData/MeshToPolyData.cxx
+++ b/src/Pipelines/MeshToPolyData/MeshToPolyData.cxx
@@ -1,0 +1,65 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkMeshFileReader.h"
+#include "itkMesh.h"
+#include "itkMeshToVTKUnstructuredGridFilter.h"
+#include "vtkGeometryFilter.h"
+#include "vtkJSONDataSetWriter.h"
+#include "vtkNew.h"
+
+int main( int argc, char * argv[] )
+{
+  if( argc < 3 )
+    {
+    std::cerr << "Usage: " << argv[0] << " <inputMesh> <outputPolyData> " << std::endl;
+    return EXIT_FAILURE;
+    }
+  const char * inputMeshFile = argv[1];
+  const char * outputPolyDataFile = argv[2];
+
+  using PixelType = float;
+  constexpr unsigned int Dimension = 3;
+  using MeshType = itk::Mesh< PixelType, Dimension >;
+  using MeshReaderType = itk::MeshFileReader< MeshType >;
+  MeshReaderType::Pointer meshReader = MeshReaderType::New();
+  meshReader->SetFileName( inputMeshFile );
+
+  using ConverterType = itk::MeshToVTKUnstructuredGridFilter< MeshType >;
+  ConverterType::Pointer converter = ConverterType::New();
+  converter->SetInput( meshReader->GetOutput() );
+
+  try
+    {
+    converter->Update();
+
+    vtkNew< vtkGeometryFilter > geometryFilter;
+    geometryFilter->SetInputData( converter->GetOutput() );
+
+    vtkNew< vtkJSONDataSetWriter > writer;
+    writer->SetFileName( outputPolyDataFile );
+    writer->SetInputConnection( geometryFilter->GetOutputPort() );
+    writer->Update();
+    }
+  catch( const std::exception & error )
+    {
+    std::cerr << "Error: " << error.what() << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  return EXIT_SUCCESS;
+}

--- a/test/Browser/runPipelineBrowserTest.js
+++ b/test/Browser/runPipelineBrowserTest.js
@@ -195,3 +195,46 @@ test('runPipelineBrowser reads a vtkPolyData from the Emscripten filesystem', (t
         })
     })
 })
+
+test('MeshToPolyData converts an itk/Mesh to a vtk.js vtkPolyData', (t) => {
+  const verifyPolyData = (polyData) => {
+    t.is(polyData.vtkClass, 'vtkPolyData')
+    t.is(polyData.points.vtkClass, 'vtkPoints')
+    t.is(polyData.points.name, 'points')
+    t.is(polyData.points.numberOfComponents, 3)
+    t.is(polyData.points.dataType, 'Float32Array')
+    t.is(polyData.points.size, 8709)
+    t.is(polyData.points.buffer.byteLength, 34836)
+    t.is(polyData.polys.vtkClass, 'vtkCellArray')
+    t.is(polyData.polys.name, 'polys')
+    t.is(polyData.polys.numberOfComponents, 1)
+    t.is(polyData.polys.dataType, 'Int32Array')
+    t.is(polyData.polys.size, 15593)
+    t.is(polyData.polys.buffer.byteLength, 62372)
+    t.end()
+  }
+
+  const fileName = 'cow.vtk'
+  const testMeshInputFilePath = `base/build/ExternalData/test/Input/${fileName}`
+  return axios.get(testMeshInputFilePath, { responseType: 'blob' })
+    .then(function (response) {
+      const jsFile = new window.File([response.data], fileName)
+      return jsFile
+    }).then(function (jsFile) {
+      return readMeshFile(null, jsFile)
+    }).then(function ({ mesh, webWorker }) {
+      webWorker.terminate()
+      const pipelinePath = 'MeshToPolyData'
+      const args = ['cow.vtk.json', 'cow.vtk.written.json']
+      const desiredOutputs = [
+        { path: args[1], type: IOTypes.vtkPolyData }
+      ]
+      const inputs = [
+        { path: args[0], type: IOTypes.Mesh, data: mesh }
+      ]
+      return runPipelineBrowser(null, pipelinePath, args, desiredOutputs, inputs)
+        .then(function ({ stdout, stderr, outputs }) {
+          verifyPolyData(outputs[0].data)
+        })
+    })
+})

--- a/test/runPipelineNodeSyncTest.js
+++ b/test/runPipelineNodeSyncTest.js
@@ -107,3 +107,33 @@ test('runPipelineNode writes and reads an itk/Mesh in the Emscripten filesystem'
   const { outputs } = runPipelineNodeSync(pipelinePath, args, desiredOutputs, inputs)
   verifyMesh(outputs[0].data)
 })
+
+test('MeshToPolyData converts an itk/Mesh to a vtk.js vtkPolyData', (t) => {
+  const verifyPolyData = (polyData) => {
+    t.is(polyData.vtkClass, 'vtkPolyData')
+    t.is(polyData.points.vtkClass, 'vtkPoints')
+    t.is(polyData.points.name, 'points')
+    t.is(polyData.points.numberOfComponents, 3)
+    t.is(polyData.points.dataType, 'Float32Array')
+    t.is(polyData.points.size, 8709)
+    t.is(polyData.points.buffer.byteLength, 34836)
+    t.is(polyData.polys.vtkClass, 'vtkCellArray')
+    t.is(polyData.polys.name, 'polys')
+    t.is(polyData.polys.numberOfComponents, 1)
+    t.is(polyData.polys.dataType, 'Int32Array')
+    t.is(polyData.polys.size, 15593)
+    t.is(polyData.polys.buffer.byteLength, 62372)
+  }
+
+  const mesh = readMeshLocalFileSync(testMeshInputFilePath)
+  const pipelinePath = path.resolve(__dirname, '..', 'src', 'Pipelines', 'MeshToPolyData', 'web-build', 'MeshToPolyData')
+  const args = ['cow.vtk.json', 'cow.vtk.written.json']
+  const desiredOutputs = [
+    { path: args[1], type: IOTypes.vtkPolyData }
+  ]
+  const inputs = [
+    { path: args[0], type: IOTypes.Mesh, data: mesh }
+  ]
+  const { outputs } = runPipelineNodeSync(pipelinePath, args, desiredOutputs, inputs)
+  verifyPolyData(outputs[0].data)
+})

--- a/test/runPipelineNodeTest.js
+++ b/test/runPipelineNodeTest.js
@@ -150,3 +150,37 @@ test('runPipelineNode reads a vtkPolyData from the Emscripten filesystem', (t) =
       verifyPolyData(outputs[0].data)
     })
 })
+
+test('MeshToPolyData converts an itk/Mesh to a vtk.js vtkPolyData', (t) => {
+  const verifyPolyData = (polyData) => {
+    t.is(polyData.vtkClass, 'vtkPolyData')
+    t.is(polyData.points.vtkClass, 'vtkPoints')
+    t.is(polyData.points.name, 'points')
+    t.is(polyData.points.numberOfComponents, 3)
+    t.is(polyData.points.dataType, 'Float32Array')
+    t.is(polyData.points.size, 8709)
+    t.is(polyData.points.buffer.byteLength, 34836)
+    t.is(polyData.polys.vtkClass, 'vtkCellArray')
+    t.is(polyData.polys.name, 'polys')
+    t.is(polyData.polys.numberOfComponents, 1)
+    t.is(polyData.polys.dataType, 'Int32Array')
+    t.is(polyData.polys.size, 15593)
+    t.is(polyData.polys.buffer.byteLength, 62372)
+  }
+
+  return readMeshLocalFile(testMeshInputFilePath)
+    .then(function (mesh) {
+      const pipelinePath = path.resolve(__dirname, '..', 'src', 'Pipelines', 'MeshToPolyData', 'web-build', 'MeshToPolyData')
+      const args = ['cow.vtk.json', 'cow.vtk.written.json']
+      const desiredOutputs = [
+        { path: args[1], type: IOTypes.vtkPolyData }
+      ]
+      const inputs = [
+        { path: args[0], type: IOTypes.Mesh, data: mesh }
+      ]
+      return runPipelineNode(pipelinePath, args, desiredOutputs, inputs)
+        .then(function ({ stdout, stderr, outputs }) {
+          verifyPolyData(outputs[0].data)
+        })
+    })
+})


### PR DESCRIPTION
Convert a itk.js Mesh JavaScript object to a vtk.js PolyData JavaScript
Object.

This is a standard pipeline to be distributed with the itk.js npm
package.