### PR TITLE
perf(readImageDICOMFileSeries): Add option to indicate a single sorte…

### DIFF
--- a/doc/content/api/browser_io.md
+++ b/doc/content/api/browser_io.md
@@ -51,9 +51,9 @@ Read an image from an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web
 
 Read a server-side generated image created with [`itk::JSONImageIO`](https://github.com/InsightSoftwareConsortium/itk-js/blob/master/include/itkJSONImageIO.h). The primary `*.json` file should be served at the given `url` and the pixel buffer file served at `url + ".data"`
 
-## readImageDICOMFileSeries(webWorker, fileList) -> { webWorker, [image](./Image.html) }
+## readImageDICOMFileSeries(webWorker, fileList, singleSortedSeries=false) -> { webWorker, [image](./Image.html) }
 
-Read an image from a series of DICOM [File](https://developer.mozilla.org/en-US/docs/Web/API/File)'s stored in an [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) or [FileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList).
+Read an image from a series of DICOM [File](https://developer.mozilla.org/en-US/docs/Web/API/File)'s stored in an [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) or [FileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList). If the files are known to be from a single, sorted series, the last argument can be set to true for performance.
 
 ## writeImageArrayBuffer(webWorker, useCompression, image, fileName, mimeType) ->  { webWorker, [arrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) }
 

--- a/doc/content/api/node_io.md
+++ b/doc/content/api/node_io.md
@@ -37,13 +37,14 @@ Read an image from a file on the local filesystem.
 
 Similar to `readImageLocalFile`, but returns the image directly instead of a promise.
 
-## readImageLocalDICOMFileSeries(directory) -> [itk/Image](./Image.html)
+## readImageLocalDICOMFileSeries(filePaths, singleSortedSeries=false) -> [itk/Image](./Image.html)
 
 Read an image from a series of DICOM files on the local filesystem.
 
-It is assumed that all the files are located in the same directory.
+If the files are known to be from a single, sorted series, the last argument can be set to true for performance.
 
-## readImageLocalDICOMFileSeriesSync(directory) -> [itk/Image](./Image.html)
+
+## readImageLocalDICOMFileSeriesSync(filePaths, singleSortedSeries=False) -> [itk/Image](./Image.html)
 
 Similar to `readImageLocalDICOMFileSeries`, but returns the image directly instead of a promise.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "itk",
-  "version": "10.2.1",
+  "version": "11.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3661,7 +3661,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -6488,7 +6489,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -7535,9 +7537,9 @@
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -11592,7 +11594,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -13444,7 +13447,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "micromatch": {
@@ -13978,7 +13982,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "lcid": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cz-conventional-changelog": "2.1.0",
     "file-api": "^0.10.4",
     "fs-extra": "^7.0.1",
-    "glob": "^7.1.3",
+    "glob": "^7.1.6",
     "json-loader": "^0.5.7",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/src/Bindings/itkDICOMImageSeriesReaderJSBinding.cxx
+++ b/src/Bindings/itkDICOMImageSeriesReaderJSBinding.cxx
@@ -33,6 +33,143 @@
 namespace itk
 {
 
+template <typename TOutputImage>
+class ITK_TEMPLATE_EXPORT QuickDICOMImageSeriesReader : public ImageSeriesReader<TOutputImage>
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(QuickDICOMImageSeriesReader);
+
+  /** Standard class type aliases. */
+  using Self = QuickDICOMImageSeriesReader;
+  using Superclass = ImageSeriesReader<TOutputImage>;
+  using Pointer = SmartPointer<Self>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(QuickDICOMImageSeriesReader, ImageSeriesReader);
+
+  /** The size of the output image. */
+  using SizeType = typename TOutputImage::SizeType;
+
+  /** The index of the output image. */
+  using IndexType = typename TOutputImage::IndexType;
+
+  /** The region of the output image. */
+  using ImageRegionType = typename TOutputImage::RegionType;
+
+  /** The pixel type of the output image. */
+  using OutputImagePixelType = typename TOutputImage::PixelType;
+
+protected:
+  QuickDICOMImageSeriesReader()
+    {
+    }
+
+  ~QuickDICOMImageSeriesReader() override
+    {
+    }
+
+  /** Does the real work. */
+  void
+  GenerateData() override
+    {
+      TOutputImage * output = this->GetOutput();
+
+      ImageRegionType requestedRegion = output->GetRequestedRegion();
+      ImageRegionType largestRegion = output->GetLargestPossibleRegion();
+      ImageRegionType sliceRegionToRequest = output->GetRequestedRegion();
+
+      // Each file must have the same size.
+      SizeType validSize = largestRegion.GetSize();
+
+      // If more than one file is being read, then the input dimension
+      // will be less than the output dimension.  In this case, set
+      // the last dimension that is other than 1 of validSize to 1.  However, if the
+      // input and output have the same number of dimensions, this should
+      // not be done because it will lower the dimension of the output image.
+      if (TOutputImage::ImageDimension != this->m_NumberOfDimensionsInImage)
+      {
+        validSize[this->m_NumberOfDimensionsInImage] = 1;
+        sliceRegionToRequest.SetSize(this->m_NumberOfDimensionsInImage, 1);
+        sliceRegionToRequest.SetIndex(this->m_NumberOfDimensionsInImage, 0);
+      }
+
+      ImageIORegion imageIORegion(this->m_NumberOfDimensionsInImage);
+      for (unsigned int dim = 0; dim < this->m_NumberOfDimensionsInImage; ++dim) {
+        imageIORegion.SetSize(dim, sliceRegionToRequest.GetSize(dim));
+        imageIORegion.SetIndex(dim, sliceRegionToRequest.GetIndex(dim));
+      }
+      // the size of the buffer is computed based on the actual number of
+      // pixels to be read and the actual size of the pixels to be read
+      // (as opposed to the sizes of the output)
+      const size_t sizeOfActualIORegion =
+        imageIORegion.GetNumberOfPixels() * (this->m_ImageIO->GetComponentSize() * this->m_ImageIO->GetNumberOfComponents());
+
+
+      // Allocate the output buffer
+      output->SetBufferedRegion(requestedRegion);
+      output->Allocate();
+
+      // progress reported on a per slice basis
+      ProgressReporter progress(this, 0, requestedRegion.GetSize(TOutputImage::ImageDimension - 1), 100);
+
+      const bool needToUpdateMetaDataDictionaryArray = false;
+
+      typename TOutputImage::InternalPixelType * outputBuffer = output->GetBufferPointer();
+      IndexType                                  sliceStartIndex = requestedRegion.GetIndex();
+      const auto                                 numberOfFiles = static_cast<int>(this->m_FileNames.size());
+
+      typename TOutputImage::PointType   prevSliceOrigin = output->GetOrigin();
+      typename TOutputImage::SpacingType outputSpacing = output->GetSpacing();
+      double                             maxSpacingDeviation = 0.0;
+      bool                               prevSliceIsValid = false;
+
+      for (int i = 0; i != numberOfFiles; ++i)
+      {
+        if (TOutputImage::ImageDimension != this->m_NumberOfDimensionsInImage)
+        {
+          sliceStartIndex[this->m_NumberOfDimensionsInImage] = i;
+        }
+
+        const bool insideRequestedRegion = requestedRegion.IsInside(sliceStartIndex);
+        const int  iFileName = i;
+        bool       nonUniformSampling = false;
+        double     spacingDeviation = 0.0;
+
+        // check if we need this slice
+        if (!insideRequestedRegion && !needToUpdateMetaDataDictionaryArray)
+        {
+          continue;
+        }
+
+        this->m_ImageIO->SetFileName(this->m_FileNames[iFileName].c_str());
+        this->m_ImageIO->SetIORegion(imageIORegion);
+
+        const size_t numberOfPixelsInSlice = sliceRegionToRequest.GetNumberOfPixels();
+
+        using AccessorFunctorType = typename TOutputImage::AccessorFunctorType;
+        const size_t numberOfInternalComponentsPerPixel = AccessorFunctorType::GetVectorLength(output);
+
+
+        const ptrdiff_t sliceOffset = (TOutputImage::ImageDimension != this->m_NumberOfDimensionsInImage)
+                                        ? (i - requestedRegion.GetIndex(this->m_NumberOfDimensionsInImage))
+                                        : 0;
+
+        const ptrdiff_t numberOfPixelComponentsUpToSlice =
+          numberOfPixelsInSlice * numberOfInternalComponentsPerPixel * sliceOffset;
+
+        typename TOutputImage::InternalPixelType * outputSliceBuffer = outputBuffer + numberOfPixelComponentsUpToSlice;
+        this->m_ImageIO->Read(outputSliceBuffer);
+
+        // report progress for read slices
+        progress.CompletedPixel();
+
+      } // end per slice loop
+    } // end GenerateData
+};
+
 /** \class DICOMImageSeriesReaderJSBinding
  *
  * \brief Provides a JavaScript binding interface to
@@ -121,10 +258,17 @@ public:
     }
 
   /** Set the directory in the Emscripten filesystem that contains the DICOM
-   * series files. */
+   * series files. Only use SetDirectory or SetFileNames, not both. */
   void SetDirectory( std::string directory )
     {
     m_Directory = directory;
+    }
+
+  /** Set filepaths in the Emscripten filesystem that contains the DICOM
+   * series files. */
+  void SetFileNames( const FileNamesContainerType filePaths )
+    {
+    m_FileNames = filePaths;
     }
 
   /** Read information fr8om the TestFile. */
@@ -389,15 +533,23 @@ private:
     {
     typedef TImage                              ImageType;
 
-
-    typedef itk::DCMTKSeriesFileNames SeriesFileNames;
-    SeriesFileNames::Pointer seriesFileNames = SeriesFileNames::New();
-    seriesFileNames->SetInputDirectory( m_Directory );
-
-    typedef itk::ImageSeriesReader< ImageType > ReaderType;
+    typedef itk::QuickDICOMImageSeriesReader< ImageType > ReaderType;
     typename ReaderType::Pointer reader = ReaderType::New();
-    const typename ReaderType::FileNamesContainer & fileNames = seriesFileNames->GetInputFileNames();
-    reader->SetFileNames( fileNames );
+    reader->SetMetaDataDictionaryArrayUpdate(false);
+
+    if (!m_FileNames.size())
+      {
+      typedef itk::DCMTKSeriesFileNames SeriesFileNames;
+      SeriesFileNames::Pointer seriesFileNames = SeriesFileNames::New();
+      seriesFileNames->SetInputDirectory( m_Directory );
+
+      const typename ReaderType::FileNamesContainer & fileNames = seriesFileNames->GetInputFileNames();
+      reader->SetFileNames( fileNames );
+      }
+    else
+      {
+      reader->SetFileNames( m_FileNames );
+      }
 
     reader->SetImageIO( m_DCMTKImageIO );
 
@@ -420,6 +572,7 @@ private:
   IOComponentType m_IOComponentType;
   IOPixelType m_IOPixelType;
   std::string m_Directory;
+  FileNamesContainerType m_FileNames;
 
   itk::DCMTKImageIO::Pointer m_DCMTKImageIO;
   ImageBase< ImageDimension >::Pointer m_ReadImage;
@@ -471,6 +624,7 @@ EMSCRIPTEN_BINDINGS(itk_dicom_image_series_reader_js_binding) {
   .function("GetIOComponentType", &itk::DICOMImageSeriesReaderJSBinding::GetIOComponentType)
   .function("GetIOPixelType", &itk::DICOMImageSeriesReaderJSBinding::GetIOPixelType)
   .function("SetDirectory", &itk::DICOMImageSeriesReaderJSBinding::SetDirectory)
+  .function("SetFileNames", &itk::DICOMImageSeriesReaderJSBinding::SetFileNames)
   .function("Read", &itk::DICOMImageSeriesReaderJSBinding::Read)
   .function("GetSpacing", &itk::DICOMImageSeriesReaderJSBinding::GetSpacing)
   .function("GetSize", &itk::DICOMImageSeriesReaderJSBinding::GetSize)

--- a/src/WebWorkers/ImageIO.worker.js
+++ b/src/WebWorkers/ImageIO.worker.js
@@ -129,9 +129,11 @@ async function readDICOMImageSeries (input) {
   })
   const mountpoint = '/work'
   seriesReaderModule.mountBlobs(mountpoint, blobs)
-  const filePath = mountpoint + '/' + input.fileDescriptions[0].name
+  const filePaths = input.fileDescriptions.map((fileDescription) => {
+    return `${mountpoint}/${fileDescription.name}`
+  })
   const image = readImageEmscriptenFSDICOMFileSeries(seriesReaderModule,
-    mountpoint, filePath)
+    filePaths, input.singleSortedSeries)
   seriesReaderModule.unmountBlobs(mountpoint)
 
   return new registerWebworker.TransferableResponse(image, [image.data.buffer])

--- a/src/readImageDICOMFileSeries.js
+++ b/src/readImageDICOMFileSeries.js
@@ -3,29 +3,42 @@ import PromiseFileReader from 'promise-file-reader'
 
 import config from './itkConfig'
 
-const readImageDICOMFileSeries = (webWorker, fileList) => {
+const readImageDICOMFileSeries = async (
+  webWorker,
+  fileList,
+  singleSortedSeries = false
+) => {
   let worker = webWorker
-  return createWebworkerPromise('ImageIO', worker)
-    .then(({ webworkerPromise, worker: usedWorker }) => {
-      worker = usedWorker
-      const fetchFileDescriptions = Array.from(fileList, function (file) {
-        return PromiseFileReader.readAsArrayBuffer(file).then(function (arrayBuffer) {
-          const fileDescription = { name: file.name, type: file.type, data: arrayBuffer }
-          return fileDescription
-        })
-      })
-
-      return Promise.all(fetchFileDescriptions).then(function (fileDescriptions) {
-        const transferables = fileDescriptions.map((description) => {
-          return description.data
-        })
-        return webworkerPromise.postMessage({ operation: 'readDICOMImageSeries', fileDescriptions: fileDescriptions, config: config },
-          transferables)
+  const { webworkerPromise, worker: usedWorker } = await createWebworkerPromise(
+    'ImageIO',
+    worker
+  )
+  worker = usedWorker
+  const fetchFileDescriptions = Array.from(fileList, function (file) {
+    return PromiseFileReader.readAsArrayBuffer(file).then(function (
+      arrayBuffer
+    ) {
+      const fileDescription = {
+        name: file.name,
+        type: file.type,
+        data: arrayBuffer
       }
-      ).then(function (image) {
-        return Promise.resolve({ image, webWorker: worker })
-      })
+      return fileDescription
     })
+  })
+
+  const fileDescriptions = await Promise.all(fetchFileDescriptions)
+  const transferables = fileDescriptions.map(description => {
+    return description.data
+  })
+  const message = {
+    operation: 'readDICOMImageSeries',
+    fileDescriptions: fileDescriptions,
+    singleSortedSeries,
+    config
+  }
+  const image = await webworkerPromise.postMessage(message, transferables)
+  return Promise.resolve({ image, webWorker: worker })
 }
 
 export default readImageDICOMFileSeries

--- a/src/readImageEmscriptenFSDICOMFileSeries.js
+++ b/src/readImageEmscriptenFSDICOMFileSeries.js
@@ -4,8 +4,9 @@ const ImageType = require('./ImageType.js')
 const imageIOComponentToJSComponent = require('./imageIOComponentToJSComponent.js')
 const imageIOPixelTypeToJSPixelType = require('./imageIOPixelTypeToJSPixelType.js')
 
-const readImageEmscriptenFSDICOMFileSeries = (seriesReaderModule, directory, firstFile) => {
+const readImageEmscriptenFSDICOMFileSeries = (seriesReaderModule, fileNames, singleSortedSeries) => {
   const seriesReader = new seriesReaderModule.ITKDICOMImageSeriesReader()
+  const firstFile = fileNames[0]
   if (!seriesReader.CanReadTestFile(firstFile)) {
     throw new Error('Could not read file: ' + firstFile)
   }
@@ -27,7 +28,16 @@ const readImageEmscriptenFSDICOMFileSeries = (seriesReaderModule, directory, fir
 
   seriesReader.SetIOComponentType(ioComponentType)
   seriesReader.SetIOPixelType(ioPixelType)
-  seriesReader.SetDirectory(directory)
+  const fileNamesContainer = new seriesReaderModule.FileNamesContainerType()
+  fileNames.forEach((fileName) => {
+    fileNamesContainer.push_back(fileName)
+  })
+  if (singleSortedSeries) {
+    seriesReader.SetFileNames(fileNamesContainer)
+  } else {
+    const directory = fileNames[0].match(/.*\//)[0]
+    seriesReader.SetDirectory(directory)
+  }
   if (seriesReader.Read()) {
     throw new Error('Could not read series')
   }

--- a/src/readImageLocalDICOMFileSeries.js
+++ b/src/readImageLocalDICOMFileSeries.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const fs = require('fs')
 
 const loadEmscriptenModule = require('./loadEmscriptenModuleNode.js')
 const readImageEmscriptenFSDICOMFileSeries = require('./readImageEmscriptenFSDICOMFileSeries.js')
@@ -7,24 +6,25 @@ const readImageEmscriptenFSDICOMFileSeries = require('./readImageEmscriptenFSDIC
 /**
  * Read an image from a series of DICOM files on the local filesystem in Node.js.
  *
- * It is assumed that all the files are located in the same directory.
- *
- * @param: directory a directory containing a single study / series on the local filesystem.
+ * @param: filenames Array of filepaths containing a DICOM study / series on the local filesystem.
+ * @param: singleSortedSeries: it is known that the files are from a single
+ * sorted series.
  */
-const readImageLocalDICOMFileSeries = (directory) => {
+const readImageLocalDICOMFileSeries = (fileNames, singleSortedSeries = false) => {
   return new Promise(function (resolve, reject) {
     const imageIOsPath = path.resolve(__dirname, 'ImageIOs')
-    const absoluteDirectory = path.resolve(directory)
     const seriesReader = 'itkDICOMImageSeriesReaderJSBinding'
-    const files = fs.readdirSync(absoluteDirectory)
     try {
-      const absoluteDirectoryWithFile = path.join(absoluteDirectory, 'myfile.dcm')
       const seriesReaderPath = path.join(imageIOsPath, seriesReader)
       const seriesReaderModule = loadEmscriptenModule(seriesReaderPath)
-      const mountedFilePath = seriesReaderModule.mountContainingDirectory(absoluteDirectoryWithFile)
+      const mountedFilePath = seriesReaderModule.mountContainingDirectory(fileNames[0])
       const mountedDir = path.dirname(mountedFilePath)
+
+      const mountedFileNames = fileNames.map((fileName) => {
+        return path.join(mountedDir, path.basename(fileName))
+      })
       const image = readImageEmscriptenFSDICOMFileSeries(seriesReaderModule,
-        mountedDir, mountedDir + '/' + files[0])
+        mountedFileNames, singleSortedSeries)
       seriesReaderModule.unmountContainingDirectory(mountedFilePath)
       resolve(image)
     } catch (err) {

--- a/test/DICOMSeriesTest.js
+++ b/test/DICOMSeriesTest.js
@@ -1,14 +1,17 @@
 const test = require('ava')
 const path = require('path')
+const glob = require('glob')
 
 const IntTypes = require(path.resolve(__dirname, '..', 'dist', 'IntTypes.js'))
 const PixelTypes = require(path.resolve(__dirname, '..', 'dist', 'PixelTypes.js'))
 const readImageLocalDICOMFileSeries = require(path.resolve(__dirname, '..', 'dist', 'readImageLocalDICOMFileSeries.js'))
 const readImageLocalDICOMFileSeriesSync = require(path.resolve(__dirname, '..', 'dist', 'readImageLocalDICOMFileSeriesSync.js'))
 
+const testSeriesDirectory = path.resolve(__dirname, '..', 'build', 'ExternalData', 'test', 'Input', 'DicomImageOrientationTest')
+const testFiles = glob.sync(`${testSeriesDirectory}/*.dcm`)
+
 test('Test reading a DICOM file', t => {
-  const testSeriesDirectory = path.resolve(__dirname, '..', 'build', 'ExternalData', 'test', 'Input', 'DicomImageOrientationTest')
-  return readImageLocalDICOMFileSeries(testSeriesDirectory).then(function (image) {
+  return readImageLocalDICOMFileSeries(testFiles).then(function (image) {
     t.is(image.imageType.dimension, 3, 'dimension')
     t.is(image.imageType.componentType, IntTypes.UInt8, 'componentType')
     t.is(image.imageType.pixelType, PixelTypes.Scalar, 'pixelType')
@@ -37,8 +40,35 @@ test('Test reading a DICOM file', t => {
 })
 
 test('Test reading a DICOM file with the synchronous API', t => {
-  const testSeriesDirectory = path.resolve(__dirname, '..', 'build', 'ExternalData', 'test', 'Input', 'DicomImageOrientationTest')
-  const image = readImageLocalDICOMFileSeriesSync(testSeriesDirectory)
+  const image = readImageLocalDICOMFileSeriesSync(testFiles)
+  t.is(image.imageType.dimension, 3, 'dimension')
+  t.is(image.imageType.componentType, IntTypes.UInt8, 'componentType')
+  t.is(image.imageType.pixelType, PixelTypes.Scalar, 'pixelType')
+  t.is(image.imageType.components, 1, 'components')
+  t.is(image.origin[0], -17.3551, 'origin[0]')
+  t.is(image.origin[1], -133.9286, 'origin[1]')
+  t.is(image.origin[2], 116.7857, 'origin[2]')
+  t.is(image.spacing[0], 1.0, 'spacing[0]')
+  t.is(image.spacing[1], 1.0, 'spacing[1]')
+  t.is(image.spacing[2], 1.3000000000000007, 'spacing[2]')
+  t.is(image.direction.getElement(0, 0), 0.0, 'direction (0, 0)')
+  t.is(image.direction.getElement(0, 1), 0.0, 'direction (0, 1)')
+  t.is(image.direction.getElement(0, 2), -1.0, 'direction (0, 2)')
+  t.is(image.direction.getElement(1, 0), 1.0, 'direction (1, 0)')
+  t.is(image.direction.getElement(1, 1), 0.0, 'direction (1, 1)')
+  t.is(image.direction.getElement(1, 2), 0.0, 'direction (1, 2)')
+  t.is(image.direction.getElement(2, 0), 0.0, 'direction (2, 0)')
+  t.is(image.direction.getElement(2, 1), -1.0, 'direction (2, 1)')
+  t.is(image.direction.getElement(2, 2), 0.0, 'direction (2, 2)')
+  t.is(image.size[0], 256, 'size[0]')
+  t.is(image.size[1], 256, 'size[1]')
+  t.is(image.size[2], 3, 'size[2]')
+  t.is(image.data.length, 3 * 65536, 'data.length')
+  t.is(image.data[1000], 5, 'data[1000]')
+})
+
+test('Test reading a DICOM file with the synchronous API, assume sorted', t => {
+  const image = readImageLocalDICOMFileSeriesSync(testFiles.sort(), true)
   t.is(image.imageType.dimension, 3, 'dimension')
   t.is(image.imageType.componentType, IntTypes.UInt8, 'componentType')
   t.is(image.imageType.pixelType, PixelTypes.Scalar, 'pixelType')


### PR DESCRIPTION
…d series

This prevents parsing and sorting of series present.

Also, use a dedicated series reader class with performance
optimizations.

BREAKING CHANGE: Arguments to readImageDICOMFileSeries and related Node functions have changed.