### PR TITLE
perf(WorkerPool): Prefer most-recently-used worker

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,9 @@ var sourcePath = path.resolve(__dirname, './dist')
 
 if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test'
 
-process.env.CHROME_BIN = require('puppeteer').executablePath()
+if (!process.env.CHROME_BIN) {
+  process.env.CHROME_BIN = require('puppeteer').executablePath()
+}
 
 module.exports = function init (config) {
   config.set({

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -24,13 +24,13 @@ class WorkerPool {
         this.results[resultIndex] = result
         if (this.taskQueue.length > 0) {
           const reTask = this.taskQueue.shift()
-          this.addTask(resultIndex, reTask)
+          this.addTask(...reTask)
         } else if (!this.addingTasks && !this.runningWorkers) {
           this.resolve(this.results)
         }
       })
     } else {
-      this.taskQueue.push(taskArgs)
+      this.taskQueue.push([resultIndex, taskArgs])
     }
   }
 

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -16,7 +16,7 @@ class WorkerPool {
   // proposal accepted and supported by default in Babel.
   addTask (resultIndex, taskArgs) {
     if (this.workerQueue.length > 0) {
-      const worker = this.workerQueue.shift()
+      const worker = this.workerQueue.pop()
       this.runningWorkers++
       this.fcn(worker, ...taskArgs).then(({ webWorker, ...result }) => {
         this.workerQueue.push(webWorker)


### PR DESCRIPTION
Re-use the last-used worker. This results in a preference for a spawned
worker and compiled wasm over replacing a `null` queue entry.