### PR TITLE
fix(readImageFile): Default to GDCM for DICOM files

### DIFF
--- a/src/MimeToImageIO.js
+++ b/src/MimeToImageIO.js
@@ -5,7 +5,7 @@ const mimeToIO = new Map([
   ['image/x-ms-bmp', 'itkBMPImageIOJSBinding'],
   ['image/x-bmp', 'itkBMPImageIOJSBinding'],
   ['image/bmp', 'itkBMPImageIOJSBinding'],
-  ['application/dicom', 'itkDCMTKImageIOJSBinding']
+  ['application/dicom', 'itkGDCMImageIOJSBinding']
 ])
 
 module.exports = mimeToIO

--- a/src/extensionToImageIO.js
+++ b/src/extensionToImageIO.js
@@ -2,8 +2,8 @@ const extensionToIO = new Map([
   ['bmp', 'itkBMPImageIOJSBinding'],
   ['BMP', 'itkBMPImageIOJSBinding'],
 
-  ['dcm', 'itkDCMTKImageIOJSBinding'],
-  ['DCM', 'itkDCMTKImageIOJSBinding'],
+  ['dcm', 'itkGDCMImageIOJSBinding'],
+  ['DCM', 'itkGDCMImageIOJSBinding'],
 
   ['gipl', 'itkGiplImageIOJSBinding'],
   ['gipl.gz', 'itkGiplImageIOJSBinding'],

--- a/test/MimeToImageIOTest.js
+++ b/test/MimeToImageIOTest.js
@@ -33,7 +33,7 @@ test('image/bmp maps to itkBMPImageIOJSBinding', t => {
   t.is(io, 'itkBMPImageIOJSBinding')
 })
 
-test('application/dicom maps to itkDCMTKImageIOJSBinding', t => {
+test('application/dicom maps to itkGDCMImageIOJSBinding', t => {
   const io = MimeToIO.get('application/dicom')
-  t.is(io, 'itkDCMTKImageIOJSBinding')
+  t.is(io, 'itkGDCMImageIOJSBinding')
 })

--- a/test/extensionToImageIOTest.js
+++ b/test/extensionToImageIOTest.js
@@ -128,9 +128,9 @@ test('gipl maps to itkGiplImageIOJSBinding', t => {
   t.is(io, 'itkGiplImageIOJSBinding')
 })
 
-test('dcm maps to itkDCMTKImageIOJSBinding', t => {
+test('dcm maps to itkGDCMImageIOJSBinding', t => {
   const io = ExtensionToIO.get('dcm')
-  t.is(io, 'itkDCMTKImageIOJSBinding')
+  t.is(io, 'itkGDCMImageIOJSBinding')
 })
 
 test('tif maps to itkTIFFImageIOJSBinding', t => {


### PR DESCRIPTION
GDCM supports more transfer syntaxes.