### PR TITLE
perf(IO): Use MEMFS over WORKERFS

### DIFF
--- a/src/EmscriptenModule/itkJSPost.js
+++ b/src/EmscriptenModule/itkJSPost.js
@@ -81,3 +81,7 @@ Module.readFile = function (path, opts) {
 Module.writeFile = function (path, data, opts) {
   return FS.writeFile(path, data, opts)
 }
+
+Module.unlink = function (path) {
+  return FS.unlink(path)
+}


### PR DESCRIPTION
WORKERFS Blob mounting turns out to have a gigantic, i.e. 10X in GDCM
DICOM series reading, performance penalty.