### PR TITLE
feat(WorkerPool): Support parallel calls to runTasks

### DIFF
--- a/examples/UnpkgIO/src/index.js
+++ b/examples/UnpkgIO/src/index.js
@@ -2,7 +2,7 @@ import readFile from 'itk/readFile'
 import curry from 'curry'
 
 const outputFileInformation = curry(function outputFileInformation (outputTextArea, event) {
-  outputTextArea.textContent = "Loading...";
+  outputTextArea.textContent = 'Loading...'
 
   const dataTransfer = event.dataTransfer
   const files = event.target.files || dataTransfer.files
@@ -21,7 +21,7 @@ const outputFileInformation = curry(function outputFileInformation (outputTextAr
         }
         return value
       }
-      outputTextArea.textContent = JSON.stringify(imageOrMeshOrPolyData, replacer, 4);
+      outputTextArea.textContent = JSON.stringify(imageOrMeshOrPolyData, replacer, 4)
     })
 })
 

--- a/examples/Webpack/src/index.js
+++ b/examples/Webpack/src/index.js
@@ -21,7 +21,7 @@ const outputFileInformation = curry(function outputFileInformation (outputTextAr
         }
         return value
       }
-      outputTextArea.textContent = JSON.stringify(imageOrMeshOrPolyData, replacer, 4);
+      outputTextArea.textContent = JSON.stringify(imageOrMeshOrPolyData, replacer, 4)
     })
 })
 

--- a/test/Browser/WebWorkerPoolTest.js
+++ b/test/Browser/WebWorkerPoolTest.js
@@ -38,7 +38,7 @@ test('WorkerPool runs and reports progress', (t) => {
 
   const poolSize = 2
   const maxTotalSplits = 4
-  const workerPool = new WorkerPool(poolSize, runPipelineBrowser, progressLogger)
+  const workerPool = new WorkerPool(poolSize, runPipelineBrowser)
 
   const fileName = 'cthead1.png'
   const testFilePath = 'base/build/ExternalData/test/Input/' + fileName
@@ -75,7 +75,7 @@ test('WorkerPool runs and reports progress', (t) => {
         taskArgsArray.push([pipelinePath, args, desiredOutputs, inputs])
       }
 
-      return workerPool.runTasks(taskArgsArray)
+      return workerPool.runTasks(taskArgsArray, progressLogger)
     }).then((results) => {
       workerPool.terminateWorkers()
 


### PR DESCRIPTION
BREAKING_CHANGE: WorkerPool's optional progressCallback is passed to runTasks instead of the constructor