### PR TITLE
fix(WorkerPool): Resolve with many task sets

### DIFF
--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -68,6 +68,7 @@ class WorkerPool {
       info.runningWorkers++
 
       this.fcn(worker, ...taskArgs).then(({ webWorker, ...result }) => {
+        info.postponed = false
         this.workerQueue.push(webWorker)
         info.runningWorkers--
         info.results[resultIndex] = result


### PR DESCRIPTION
When runTasks is called many times repeatedly with small tasks, the
worker can be surrendered and not used for the next task -- the Promise
will never resolve.