### PR TITLE
Disable threads for openjp2

### DIFF
--- a/src/Docker/itk-js-base/Dockerfile
+++ b/src/Docker/itk-js-base/Dockerfile
@@ -11,6 +11,8 @@ RUN git clone https://github.com/InsightSoftwareConsortium/ITK.git && \
   cd ITK && \
   git checkout ${ITK_GIT_TAG} && \
   cd ../ && \
+  sed -i -e '/^option(OPJ_USE_THREAD/c\option(OPJ_USE_THREAD "use threads" OFF)' \
+    /ITK/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/src/lib/openjp2/CMakeLists.txt && \
   mkdir ITK-build && \
   cd ITK-build && \
   cmake \
@@ -33,6 +35,7 @@ RUN git clone https://github.com/InsightSoftwareConsortium/ITK.git && \
     -DModule_Cuberille:BOOL=ON \
     -DModule_TotalVariation:BOOL=ON \
     -DModule_IOMeshSTL:BOOL=ON \
+    -DOPJ_USE_THREAD:BOOL=OFF \
     ../ITK && \
   ninja -j7 && \
   find . -name '*.o' -delete && \


### PR DESCRIPTION
This should fix https://github.com/Kitware/paraview-glance/issues/367.

Issue: openjp2 expects threads to be on by default, so it hangs while waiting for threads to initialize (which they never will, presently). This affects loading jpeg2000 images.

The `OPJ_USE_THREAD:BOOL=OFF` flag didn't work for me initially, so I change the openjp2 CMake file to turn off the threads option. Is there a better way of ensuring the option gets applied to gdcm's openjp2 lib? I can try again with just the flag (and without the sed hackery).