### PR TITLE
#369 Fix CanWriteFile is not a function

### DIFF
--- a/src/writeImageLocalFileSync.js
+++ b/src/writeImageLocalFileSync.js
@@ -36,6 +36,7 @@ const writeImageLocalFileSync = (useCompression, image, filePath) => {
       const imageIO = new Module.ITKImageIO()
       const mountedFilePath = Module.mountContainingDirectory(absoluteFilePath)
       imageIO.SetFileName(mountedFilePath)
+      if (typeof imageIO.CanWriteFile !== "function") continue;
       if (imageIO.CanWriteFile(mountedFilePath)) {
         io = ImageIOIndex[idx]
         Module.unmountContainingDirectory(mountedFilePath)


### PR DESCRIPTION
ImageIO modules don't have `CanWriteFile` function defined, it causes the module to throw an errors
this fix skip modules that don't have this function