### PR TITLE
fix(Node.jsExample): Correct error with unknown file type write attempt

### DIFF
--- a/examples/Node.js/package.json
+++ b/examples/Node.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itk-convert",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convert image or mesh files from one format to another.",
   "bin": {
     "itk-convert": "./src/itk-convert.js"
@@ -31,6 +31,6 @@
   "homepage": "https://github.com/InsightSoftwareConsortium/itk-js#readme",
   "dependencies": {
     "commander": "^2.14.1",
-    "itk": "^12.3.0"
+    "itk": "^13.1.4"
   }
 }


### PR DESCRIPTION
The error now contains a traceback that starts with `Error: Could not
find IO for: [...]`
