### PR TITLE
Support cancel pending tasks which have not yet run

### DIFF
--- a/src/WebWorkers/Pipeline.worker.js
+++ b/src/WebWorkers/Pipeline.worker.js
@@ -26,68 +26,68 @@ async function runPipeline (pipelineModule, args, outputs, inputs) {
   if (result.outputs) {
     result.outputs.forEach(function (output) {
       if (output.type === IOTypes.Binary) {
-          // Binary data
-          const transferable = getTransferable(output.data)
-          if (transferable) {
-            transferables.push(transferable)
-          }
+        // Binary data
+        const transferable = getTransferable(output.data)
+        if (transferable) {
+          transferables.push(transferable)
+        }
       } else if (output.type === IOTypes.Image) {
-          // Image data
-          const transferable = getTransferable(output.data.data)
+        // Image data
+        const transferable = getTransferable(output.data.data)
+        if (transferable) {
+          transferables.push(transferable)
+        }
+      } else if (output.type === IOTypes.Mesh) {
+        // Mesh data
+        if (output.data.points) {
+          const transferable = getTransferable(output.data.points)
           if (transferable) {
             transferables.push(transferable)
           }
-      } else if (output.type === IOTypes.Mesh) {
-          // Mesh data
-          if (output.data.points) {
-            const transferable = getTransferable(output.data.points)
-            if (transferable) {
-              transferables.push(transferable)
-            }
+        }
+        if (output.data.pointData) {
+          const transferable = getTransferable(output.data.pointData)
+          if (transferable) {
+            transferables.push(transferable)
           }
-          if (output.data.pointData) {
-            const transferable = getTransferable(output.data.pointData)
-            if (transferable) {
-              transferables.push(transferable)
-            }
+        }
+        if (output.data.cells) {
+          const transferable = getTransferable(output.data.cells)
+          if (transferable) {
+            transferables.push(transferable)
           }
-          if (output.data.cells) {
-            const transferable = getTransferable(output.data.cells)
-            if (transferable) {
-              transferables.push(transferable)
-            }
+        }
+        if (output.data.cellData) {
+          const transferable = getTransferable(output.data.cellData)
+          if (transferable) {
+            transferables.push(transferable)
           }
-          if (output.data.cellData) {
-            const transferable = getTransferable(output.data.cellData)
-            if (transferable) {
-              transferables.push(transferable)
-            }
-          }
+        }
       } else if (output.type === IOTypes.vtkPolyData) {
-          // vtkPolyData data
-          const polyData = output.data
-          const cellTypes = ['points', 'verts', 'lines', 'polys', 'strips']
-          cellTypes.forEach((cellName) => {
-            if (polyData[cellName]) {
-              const transferable = getTransferable(polyData[cellName])
+        // vtkPolyData data
+        const polyData = output.data
+        const cellTypes = ['points', 'verts', 'lines', 'polys', 'strips']
+        cellTypes.forEach((cellName) => {
+          if (polyData[cellName]) {
+            const transferable = getTransferable(polyData[cellName])
+            if (transferable) {
+              transferables.push(transferable)
+            }
+          }
+        })
+
+        const dataSetType = ['pointData', 'cellData', 'fieldData']
+        dataSetType.forEach((dataName) => {
+          if (polyData[dataName]) {
+            const data = polyData[dataName]
+            data.arrays.forEach((array) => {
+              const transferable = getTransferable(array.data)
               if (transferable) {
                 transferables.push(transferable)
               }
-            }
-          })
-
-          const dataSetType = ['pointData', 'cellData', 'fieldData']
-          dataSetType.forEach((dataName) => {
-            if (polyData[dataName]) {
-              const data = polyData[dataName]
-              data.arrays.forEach((array) => {
-                const transferable = getTransferable(array.data)
-                if (transferable) {
-                  transferables.push(transferable)
-                }
-              })
-            }
-          })
+            })
+          }
+        })
       }
     })
   }

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -19,9 +19,13 @@ class WorkerPool {
    * Run the tasks specified by the arguments in the taskArgsArray that will
    * be passed to the pool fcn.
    *
-   * An optional progressCallback will be cassed with the number of complete
+   * An optional progressCallback will be called with the number of complete
    * tasks and the total number of tasks as arguments every time a task has
    * completed.
+   *
+   * Returns an object containing a promise ('promise') to communicate results
+   * as well as an id ('runId') which can be used to cancel any remaining pending
+   * tasks before they complete.
    */
   runTasks (taskArgsArray, progressCallback) {
     const info = {
@@ -30,23 +34,27 @@ class WorkerPool {
       addingTasks: false,
       postponed: false,
       runningWorkers: 0,
-      progressCallback: progressCallback
+      progressCallback: progressCallback,
+      canceled: false
     }
     this.runInfo.push(info)
     info.index = this.runInfo.length - 1
-    return new Promise((resolve, reject) => {
-      info.resolve = resolve
-      info.reject = reject
+    return {
+      promise: new Promise((resolve, reject) => {
+        info.resolve = resolve
+        info.reject = reject
 
-      info.results = new Array(taskArgsArray.length)
-      info.completedTasks = 0
+        info.results = new Array(taskArgsArray.length)
+        info.completedTasks = 0
 
-      info.addingTasks = true
-      taskArgsArray.forEach((taskArg, index) => {
-        this.addTask(info.index, index, taskArg)
-      })
-      info.addingTasks = false
-    })
+        info.addingTasks = true
+        taskArgsArray.forEach((taskArg, index) => {
+          this.addTask(info.index, index, taskArg)
+        })
+        info.addingTasks = false
+      }),
+      runId: info.index
+    }
   }
 
   terminateWorkers () {
@@ -59,36 +67,50 @@ class WorkerPool {
     }
   }
 
+  cancel (runId) {
+    const info = this.runInfo[runId]
+    if (info) {
+      info.canceled = true
+    }
+  }
+
   // todo: change to #addTask(resultIndex, taskArgs) { after private methods
   // proposal accepted and supported by default in Babel.
   addTask (infoIndex, resultIndex, taskArgs) {
     const info = this.runInfo[infoIndex]
+
+    if (info && info.canceled) {
+      this.clearTask(info.index)
+      info.reject('Remaining tasks canceled')
+      return
+    }
+
     if (this.workerQueue.length > 0) {
       const worker = this.workerQueue.pop()
       info.runningWorkers++
-
       this.fcn(worker, ...taskArgs).then(({ webWorker, ...result }) => {
         this.workerQueue.push(webWorker)
-        info.runningWorkers--
-        info.results[resultIndex] = result
-        info.completedTasks++
-        if (info.progressCallback) {
-          info.progressCallback(info.completedTasks, info.results.length)
-        }
+        // Check if this task was canceled while it was getting done
+        if (this.runInfo[infoIndex] !== null) {
+          info.runningWorkers--
+          info.results[resultIndex] = result
+          info.completedTasks++
+          if (info.progressCallback) {
+            info.progressCallback(info.completedTasks, info.results.length)
+          }
 
-        if (info.taskQueue.length > 0) {
-          const reTask = info.taskQueue.shift()
-          this.addTask(infoIndex, ...reTask)
-        } else if (!info.addingTasks && !info.runningWorkers) {
-          const results = info.results
-          const clearIndex = info.index
-          this.runInfo[clearIndex] = null
-          info.resolve(results)
+          if (info.taskQueue.length > 0) {
+            const reTask = info.taskQueue.shift()
+            this.addTask(infoIndex, ...reTask)
+          } else if (!info.addingTasks && !info.runningWorkers) {
+            const results = info.results
+            this.clearTask(info.index)
+            info.resolve(results)
+          }
         }
       }).catch((error) => {
         const reject = info.reject
-        const clearIndex = info.index
-        this.runInfo[clearIndex] = null
+        this.clearTask(info.index)
         reject(error)
       })
     } else {
@@ -105,6 +127,16 @@ class WorkerPool {
         }, 50)
       }
     }
+  }
+
+  // todo: change to #clearTask(clearIndex) { after private methods
+  // proposal accepted and supported by default in Babel.
+  clearTask (clearIndex) {
+    this.runInfo[clearIndex].results = null
+    this.runInfo[clearIndex].taskQueue = null
+    this.runInfo[clearIndex].progressCallback = null
+    this.runInfo[clearIndex].canceled = null
+    this.runInfo[clearIndex] = null
   }
 }
 

--- a/src/readImageDICOMFileSeries.js
+++ b/src/readImageDICOMFileSeries.js
@@ -61,13 +61,13 @@ const readImageDICOMFileSeries = async (
       const block = fileDescriptions.slice(index, index + seriesBlockSize)
       taskArgsArray.push([block, singleSortedSeries])
     }
-    const results = await workerPool.runTasks(taskArgsArray)
+    const results = await workerPool.runTasks(taskArgsArray).promise
     const images = results.map((result) => result.image)
     const stacked = stackImages(images)
     return { image: stacked, webWorkerPool: workerPool }
   } else {
     const taskArgsArray = [[fileDescriptions, singleSortedSeries]]
-    const results = await workerPool.runTasks(taskArgsArray)
+    const results = await workerPool.runTasks(taskArgsArray).promise
     return { image: results[0].image, webWorkerPool: workerPool }
   }
 }

--- a/test/Browser/WebWorkerPoolTest.js
+++ b/test/Browser/WebWorkerPoolTest.js
@@ -63,7 +63,7 @@ test('WorkerPool runs and reports progress', (t) => {
         taskArgsArray.push([pipelinePath, args, desiredOutputs, inputs])
       }
 
-      return workerPool.runTasks(taskArgsArray, progressLogger)
+      return workerPool.runTasks(taskArgsArray, progressLogger).promise
     }).then((results) => {
       workerPool.terminateWorkers()
 


### PR DESCRIPTION
This PR changes the behavior of the `WorkerPool.runTasks` method so instead of returning a promise, it returns an object containing the original promise along with an id that can be used to cancel pending tasks before they have been executed by a worker (cancelation is achieved via a new `cancel(runId)` method added to the `WorkerPool` api).