### PR TITLE
Read dicom tags

### DIFF
--- a/doc/content/api/browser_io.md
+++ b/doc/content/api/browser_io.md
@@ -69,6 +69,19 @@ If the files are known to be from a single, sorted series, the last argument can
 
 The used `webWorkerPool` is returned to enable resource cleanup by calling `.terminateWorkers()`.
 
+## readDICOMTags(webWorker, file, tags=[]) -> { tags, webWorker }
+
+Read tags from a DICOM [File](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
+Tags should be of the form `"GGGG|EEEE"`, where `GGGG` is the group ID in hex and `EEEE` is the element ID in hex. As an example, "0010|0010" is the PatientID.
+Hexadecimal strings are treated case-insensitively.
+A web worker object can be optionally provided to re-use a previously created web worker.
+Otherwise, leave this null.
+
+Returns:
+- tags: a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) containing the mapping from tag to tag value.
+- webWorker: a webworker that can be re-used.
+
 ## writeImageArrayBuffer(webWorker, useCompression, image, fileName, mimeType) ->  { webWorker, [arrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) }
 
 Write an image to a an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).

--- a/doc/content/api/node_io.md
+++ b/doc/content/api/node_io.md
@@ -48,6 +48,19 @@ If the files are known to be from a single, sorted series, the last argument can
 
 Similar to `readImageLocalDICOMFileSeries`, but returns the image directly instead of a promise.
 
+## readDICOMTagsLocalFile(file, tags=[]) -> Promise&lt;Map&gt;
+
+Read tags from a DICOM [File](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
+Tags should be of the form `"GGGG|EEEE"`, where `GGGG` is the group ID in hex and `EEEE` is the element ID in hex. As an example, "0010|0010" is the PatientID.
+Hexadecimal strings are treated case-insensitively.
+
+Returns a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) containing the mapping from tag to tag value.
+
+## readDICOMTagsLocalFileSync(file, tags=[]) -> Map
+
+Similar to `readDICOMTagsLocalFile`, but returns the tag Map directly instead of a promise.
+
 ## writeImageLocalFile(useCompression, image, filePath) -> null
 
 Write an image to a file on the local filesystem with Node.js.

--- a/src/Bindings/itkDICOMTagReaderJSBinding.cxx
+++ b/src/Bindings/itkDICOMTagReaderJSBinding.cxx
@@ -1,0 +1,129 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <emscripten.h>
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "itkCommonEnums.h"
+#include "itkGDCMImageIO.h"
+#include "itkGDCMSeriesFileNames.h"
+#include "itkImageIOBase.h"
+#include "itkMetaDataObject.h"
+
+namespace itk
+{
+
+/** \class DICOMTagReaderJSBinding
+ *
+ * \brief Reads DICOM tags from a DICOM object.
+ */
+class DICOMTagReaderJSBinding
+{
+public:
+  using MetaDictType = itk::MetaDataDictionary;
+  using TagMapType = std::map<std::string, std::string>;
+
+  DICOMTagReaderJSBinding()
+    : m_dirtyCache(true)
+  {
+    m_GDCMImageIO = GDCMImageIO::New();
+  }
+
+  /** Sets file name. */
+  void
+  SetFileName(std::string file)
+  {
+    m_fileName = file;
+    m_GDCMImageIO->SetFileName(file);
+    m_dirtyCache = true;
+  }
+
+  /** Verify file can be read. */
+  bool
+  CanReadFile(std::string file)
+  {
+    return m_GDCMImageIO->CanReadFile(file.c_str());
+  }
+
+  std::string
+  ReadTag(std::string tag)
+  {
+
+    if (m_dirtyCache)
+    {
+      m_GDCMImageIO->SetUseStreamedReading(true);
+      m_GDCMImageIO->ReadImageInformation();
+      m_tagDict = m_GDCMImageIO->GetMetaDataDictionary();
+      m_dirtyCache = false;
+    }
+
+    auto value = unpackMetaAsString(m_tagDict[tag]);
+    return value;
+  }
+
+  TagMapType
+  ReadAllTags()
+  {
+
+    if (m_dirtyCache)
+    {
+      m_GDCMImageIO->SetUseStreamedReading(true);
+      m_GDCMImageIO->ReadImageInformation();
+      m_tagDict = m_GDCMImageIO->GetMetaDataDictionary();
+      m_dirtyCache = false;
+    }
+
+    TagMapType allTagsDict;
+    for (auto it = m_tagDict.Begin(); it != m_tagDict.End(); ++it)
+    {
+      auto value = unpackMetaAsString(it->second);
+      allTagsDict[it->first] = value;
+    }
+
+    return allTagsDict;
+  }
+
+private:
+  std::string               m_fileName;
+  itk::GDCMImageIO::Pointer m_GDCMImageIO;
+  MetaDictType              m_tagDict;
+  bool                      m_dirtyCache;
+};
+
+} // end namespace itk
+
+EMSCRIPTEN_BINDINGS(itk_dicom_tag_reader_js_binding)
+{
+  emscripten::register_vector<std::string>("vector<std::string>");
+  emscripten::register_map<std::string, std::string>("TagMapType");
+  emscripten::class_<itk::DICOMTagReaderJSBinding>("ITKDICOMTagReader")
+    .constructor<>()
+    .function("SetFileName", &itk::DICOMTagReaderJSBinding::SetFileName)
+    .function("CanReadFile", &itk::DICOMTagReaderJSBinding::CanReadFile)
+    .function("ReadTag", &itk::DICOMTagReaderJSBinding::ReadTag)
+    .function("ReadAllTags", &itk::DICOMTagReaderJSBinding::ReadAllTags);
+}

--- a/src/Bindings/itkDICOMTagReaderJSBinding.cxx
+++ b/src/Bindings/itkDICOMTagReaderJSBinding.cxx
@@ -23,16 +23,470 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <string.h>
 
 #include <emscripten.h>
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
+
+#include <iconv.h>
 
 #include "itkCommonEnums.h"
 #include "itkGDCMImageIO.h"
 #include "itkGDCMSeriesFileNames.h"
 #include "itkImageIOBase.h"
 #include "itkMetaDataObject.h"
+
+const std::string      DEFAULT_ENCODING("ISO_IR 6");
+const std::string      DEFAULT_ISO_2022_ENCODING("ISO 2022 IR 6");
+constexpr const char * ASCII = "ASCII";
+
+// delimiters: CR, LF, FF, ESC, TAB (see
+//  http://dicom.nema.org/medical/dicom/current/output/html/part05.html#sect_6.1.3,
+//  table 6.1-1)
+// Also includes 05/12 (BACKSLASH in IR 13 or YEN SIGN in IR 14), since that
+//  separates Data Element Values and it resets to initial charset.
+//  See: dicom part 5, sect 6.1.2.5.3
+constexpr const char * DEFAULT_DELIMS = "\x1b\x09\x0a\x0c\x0d\x5c";
+// DEFAULT_DELIMS + "^" and "="
+constexpr const char * PATIENT_NAME_DELIMS = "\x1b\x09\x0a\x0c\x0d\x5c^=";
+
+std::string
+unpackMetaAsString(const itk::MetaDataObjectBase::Pointer & metaValue)
+{
+  using MetaDataStringType = itk::MetaDataObject<std::string>;
+  MetaDataStringType::Pointer value = dynamic_cast<MetaDataStringType *>(metaValue.GetPointer());
+  if (value != nullptr)
+  {
+    return value->GetMetaDataObjectValue();
+  }
+  return {};
+}
+
+// If not found, then pos == len
+size_t
+findDelim(const char * str, size_t len, size_t pos = 0, const char * delims = DEFAULT_DELIMS)
+{
+  while (pos < len && strchr(delims, str[pos]) == nullptr)
+  {
+    ++pos;
+  }
+  return pos;
+}
+
+std::string
+trimWhitespace(const std::string & term)
+{
+  auto start = term.begin();
+  auto end = term.end();
+
+  while (start != end && std::isspace(*start))
+  {
+    ++start;
+  }
+
+  // need to --end once before checking isspace
+  do
+  {
+    --end;
+  } while (end != start && std::isspace(*end));
+
+  return std::string(start, end + 1);
+}
+
+std::string
+normalizeTerm(const std::string & term)
+{
+  return trimWhitespace(term);
+}
+
+const char *
+definedTermToIconvCharset(const std::string & defTerm)
+{
+  // be strict about comparing defined terms, so no fancy parsing
+  // that could possibly make these operations faster.
+  // See:
+  // http://dicom.nema.org/medical/dicom/current/output/chtml/part02/sect_D.6.2.html
+  if (defTerm == "ISO_IR 6" || defTerm == "ISO 2022 IR 6")
+  {
+    return ASCII;
+  }
+  if (defTerm == "ISO_IR 100" || defTerm == "ISO 2022 IR 100")
+  {
+    return "ISO-8859-1"; // Latin 1
+  }
+  if (defTerm == "ISO_IR 101" || defTerm == "ISO 2022 IR 101")
+  {
+    return "ISO-8859-2"; // Latin 2
+  }
+  if (defTerm == "ISO_IR 109" || defTerm == "ISO 2022 IR 109")
+  {
+    return "ISO-8859-3"; // Latin 3
+  }
+  if (defTerm == "ISO_IR 110" || defTerm == "ISO 2022 IR 110")
+  {
+    return "ISO-8859-4"; // Latin 4
+  }
+  if (defTerm == "ISO_IR 144" || defTerm == "ISO 2022 IR 144")
+  {
+    return "ISO-8859-5"; // Cyrillic
+  }
+  if (defTerm == "ISO_IR 127" || defTerm == "ISO 2022 IR 127")
+  {
+    return "ISO-8859-6"; // Arabic
+  }
+  if (defTerm == "ISO_IR 126" || defTerm == "ISO 2022 IR 126")
+  {
+    return "ISO-8859-7"; // Greek
+  }
+  if (defTerm == "ISO_IR 138" || defTerm == "ISO 2022 IR 138")
+  {
+    return "ISO-8859-8"; // Hebrew
+  }
+  if (defTerm == "ISO_IR 148" || defTerm == "ISO 2022 IR 148")
+  {
+    return "ISO-8859-9"; // Latin 5, Turkish
+  }
+  if (defTerm == "ISO_IR 13" || defTerm == "ISO 2022 IR 13")
+  {
+    // while technically not strict, SHIFT_JIS succeeds JIS X 0201
+    // See: https://en.wikipedia.org/wiki/JIS_X_0201
+    return "SHIFT_JIS"; // Japanese
+  }
+  if (defTerm == "ISO_IR 166" || defTerm == "ISO 2022 IR 166")
+  {
+    return "TIS-620"; // Thai
+  }
+  if (defTerm == "ISO 2022 IR 87")
+  {
+    // see: https://en.wikipedia.org/wiki/JIS_X_0208
+    return "ISO-2022-JP"; // Japanese
+  }
+  if (defTerm == "ISO 2022 IR 159")
+  {
+    // see: https://en.wikipedia.org/wiki/JIS_X_0212
+    return "ISO-2022-JP-1"; // Japanese
+  }
+  if (defTerm == "ISO 2022 IR 149")
+  {
+    return "EUC-KR"; // Korean
+  }
+  if (defTerm == "ISO 2022 IR 58")
+  {
+    return "EUC-CN"; // Chinese
+  }
+  if (defTerm == "ISO_IR 192")
+  {
+    return "UTF-8";
+  }
+  if (defTerm == "GB18030")
+  {
+    return "GB18030";
+  }
+  if (defTerm == "GBK")
+  {
+    return "GBK";
+  }
+  return nullptr;
+}
+
+// seq should be the sequence after the ESC char
+// return value should match in definedTermToIconvCharset
+const char *
+iso2022EscSelectCharset(const char * seq)
+{
+  if (seq[0] == '(' && seq[1] == 'B')
+  {
+    return "ISO 2022 IR 6";
+  }
+  if (seq[0] == '-' && seq[1] == 'A')
+  {
+    return "ISO 2022 IR 100";
+  }
+  if (seq[0] == '-' && seq[1] == 'B')
+  {
+    return "ISO 2022 IR 101";
+  }
+  if (seq[0] == '-' && seq[1] == 'C')
+  {
+    return "ISO 2022 IR 109";
+  }
+  if (seq[0] == '-' && seq[1] == 'D')
+  {
+    return "ISO 2022 IR 110";
+  }
+  if (seq[0] == '-' && seq[1] == 'L')
+  {
+    return "ISO 2022 IR 144";
+  }
+  if (seq[0] == '-' && seq[1] == 'G')
+  {
+    return "ISO 2022 IR 127";
+  }
+  if (seq[0] == '-' && seq[1] == 'F')
+  {
+    return "ISO 2022 IR 126";
+  }
+  if (seq[0] == '-' && seq[1] == 'H')
+  {
+    return "ISO 2022 IR 138";
+  }
+  if (seq[0] == '-' && seq[1] == 'M')
+  {
+    return "ISO 2022 IR 148";
+  }
+  // technically 'J' corresponds to IR 14, byt SHIFT_JIS should still work
+  if (seq[0] == '-' && (seq[1] == 'I' || seq[1] == 'J'))
+  {
+    return "ISO 2022 IR 13";
+  }
+  if (seq[0] == '-' && seq[1] == 'T')
+  {
+    return "ISO 2022 IR 166";
+  }
+  if (seq[0] == '$' && seq[1] == 'B')
+  {
+    return "ISO 2022 IR 87";
+  }
+  if (seq[0] == '$' && seq[1] == '(' && seq[2] == 'D')
+  {
+    return "ISO 2022 IR 159";
+  }
+  if (seq[0] == '$' && seq[1] == ')' && seq[2] == 'C')
+  {
+    return "ISO 2022 IR 149";
+  }
+  if (seq[0] == '$' && seq[1] == ')' && seq[2] == 'A')
+  {
+    return "ISO 2022 IR 58";
+  }
+  if ((seq[0] == ')' && seq[1] == 'I') || (seq[0] == '(' && seq[1] == 'J'))
+  {
+    return "ISO 2022 IR 13";
+  }
+  return "";
+}
+
+// seq should point after the ESC char. Returned length will
+// not include ESC char.
+size_t
+iso2022EscSeqLength(const char * seq)
+{
+  if (seq[0] == '$' && seq[1] >= '(' && seq[1] <= '/')
+  {
+    return 3;
+  }
+  return 2;
+}
+
+class CharStringToUTF8Converter
+{
+public:
+  // See: setSpecificCharacterSet(const char *)
+  CharStringToUTF8Converter(const std::string & spcharsets)
+    : CharStringToUTF8Converter(spcharsets.c_str())
+  {}
+  CharStringToUTF8Converter(const char * spcharsets)
+    : handlePatientName(false)
+  {
+    this->setSpecificCharacterSet(spcharsets);
+  };
+
+  /**
+   * Input must be the DICOM SpecificCharacterSet element value.
+   * See:
+   * http://dicom.nema.org/medical/dicom/current/output/html/part03.html#sect_C.12.1.1.2
+   */
+  void
+  setSpecificCharacterSet(const char * spcharsets)
+  {
+    std::string        specificCharacterSet(spcharsets);
+    std::string        token;
+    std::istringstream tokStream(specificCharacterSet);
+
+    m_charsets.clear();
+
+    int count = 0;
+    while (std::getline(tokStream, token, '\\'))
+    {
+      token = normalizeTerm(token);
+
+      // case: first element is empty. Use default ISO-IR 6 encoding.
+      if (token.size() == 0 && count == 0)
+      {
+        m_charsets.push_back(DEFAULT_ENCODING);
+        // "Hack" to handle case where ISO-646 (dicom default encoding) is
+        // implicitly first in the list. Since we check for charset existence when
+        // switching charsets as per ISO 2022, we put both regular and ISO 2022
+        // names for the default encoding.
+        m_charsets.push_back(DEFAULT_ISO_2022_ENCODING);
+      }
+      else if (m_charsets.end() == std::find(m_charsets.begin(), m_charsets.end(), token))
+      {
+        // case: no duplicates
+        const char * chname = definedTermToIconvCharset(token);
+        // handle charsets that do not allow code extensions
+        if (count > 0 && (token == "GB18030" || token == "GBK" || token == "ISO_IR 192"))
+        {
+          std::cerr << "WARN: charset " << token << " does not support code extensions; ignoring" << std::endl;
+        }
+        else if (chname != nullptr && chname != ASCII)
+        {
+          // ISO_IR 6 isn't a formally recognized defined term, so use ASCII
+          // above.
+          m_charsets.push_back(token);
+        }
+      }
+      else
+      {
+        std::cerr << "WARN: Found duplicate charset '" + token + "'; ignoring" << std::endl;
+      }
+      ++count;
+    }
+
+    if (count == 0)
+    {
+      // use default encoding
+      m_charsets.push_back(DEFAULT_ENCODING);
+    }
+
+    if (m_charsets.size() == 0)
+    {
+      std::cerr << "WARN: Found no suitable charsets!" << std::endl;
+    }
+  }
+
+  std::string
+  convertCharStringToUTF8(const std::string & str)
+  {
+    size_t len = str.size();
+    return this->convertCharStringToUTF8(str.c_str(), len);
+  }
+
+  std::string
+  convertCharStringToUTF8(const char * str, size_t len)
+  {
+    // m_charsets must always have at least 1 element prior to calling
+    const char * initialCharset = definedTermToIconvCharset(m_charsets[0]);
+    if (initialCharset == nullptr)
+    {
+      return {};
+    }
+
+    iconv_t cd = iconv_open("UTF-8", initialCharset);
+    if (cd == (iconv_t)-1)
+    {
+      return {};
+    }
+
+    int                     utf8len = len * 4;
+    std::unique_ptr<char[]> result(new char[utf8len + 1]()); // UTF8 will have max length of utf8len
+
+    // make a copy because iconv requires a char *
+    char * copiedStr = (char *)malloc(len + 1);
+    strncpy(copiedStr, str, len);
+
+    char * inbuf = copiedStr;
+    char * outbuf = result.get();
+    size_t inbytesleft = len;
+    size_t outbytesleft = utf8len;
+
+    // special case: only one charset, so assume string is just that charset.
+    if (m_charsets.size() == 1)
+    {
+      iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+    }
+    else
+    {
+      size_t fragmentStart = 0;
+      size_t fragmentEnd = 0;
+
+      while (fragmentStart < len)
+      {
+        const char * delims = this->handlePatientName ? PATIENT_NAME_DELIMS : DEFAULT_DELIMS;
+        // fragmentEnd will always be end of current fragment (exclusive end)
+        fragmentEnd = findDelim(str, len, fragmentStart + 1, delims);
+        inbuf = copiedStr + fragmentStart;
+        inbytesleft = fragmentEnd - fragmentStart;
+
+        iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+
+        fragmentStart = fragmentEnd;
+        bool isEsc = str[fragmentEnd] == 0x1b;
+
+        if (fragmentStart < len)
+        {
+          const char * nextCharset;
+          int          seek = 0;
+
+          if (isEsc)
+          { // case: ISO 2022 escape encountered
+            const char * escSeq = copiedStr + fragmentStart + 1;
+
+            const char * nextTerm = iso2022EscSelectCharset(escSeq);
+            nextCharset = definedTermToIconvCharset(std::string(nextTerm));
+            if (nextCharset == nullptr || m_charsets.end() == std::find(m_charsets.begin(), m_charsets.end(), nextTerm))
+            {
+              std::cerr << "WARN: bailing because invalid charset: " << nextTerm << std::endl;
+              break; // bail out
+            }
+
+            // ISO-2022-JP is a variant on ISO 2022 for japanese, and so
+            // it defines its own escape sequences. As such, do not skip the
+            // escape sequences for ISO-2022-JP, so iconv can properly interpret
+            // them.
+            if (0 != strcmp("ISO-2022-JP", nextCharset) && 0 != strcmp("ISO-2022-JP-1", nextCharset))
+            {
+              seek = iso2022EscSeqLength(escSeq) + 1;
+            }
+          }
+          else
+          { // case: hit a CR, LF, or FF
+            // reset to initial charset
+            nextCharset = initialCharset;
+          }
+
+          if (0 != iconv_close(cd))
+          {
+            std::cerr << "WARN: bailing because iconv_close" << std::endl;
+            break; // bail out
+          }
+          cd = iconv_open("UTF-8", nextCharset);
+          if (cd == (iconv_t)-1)
+          {
+            std::cerr << "WARN: bailing because iconv_open" << std::endl;
+            break; // bail out
+          }
+
+          fragmentStart += seek;
+        }
+      }
+    }
+
+    free(copiedStr);
+    iconv_close(cd);
+
+    // since result is filled with NULL bytes, string constructor will figure out
+    // the correct string ending.
+    return std::string(result.get());
+  }
+
+  bool
+  getHandlePatientName()
+  {
+    return this->handlePatientName;
+  }
+
+  void
+  setHandlePatientName(bool yn)
+  {
+    this->handlePatientName = yn;
+  }
+
+private:
+  std::vector<std::string> m_charsets;
+  bool                     handlePatientName;
+};
 
 namespace itk
 {
@@ -78,11 +532,13 @@ public:
       m_GDCMImageIO->SetUseStreamedReading(true);
       m_GDCMImageIO->ReadImageInformation();
       m_tagDict = m_GDCMImageIO->GetMetaDataDictionary();
+      auto specificCharacterSet = unpackMetaAsString(m_tagDict["0008|0005"]);
+      m_decoder = CharStringToUTF8Converter(specificCharacterSet);
       m_dirtyCache = false;
     }
 
     auto value = unpackMetaAsString(m_tagDict[tag]);
-    return value;
+    return m_decoder.convertCharStringToUTF8(value);
   }
 
   TagMapType
@@ -94,6 +550,8 @@ public:
       m_GDCMImageIO->SetUseStreamedReading(true);
       m_GDCMImageIO->ReadImageInformation();
       m_tagDict = m_GDCMImageIO->GetMetaDataDictionary();
+      auto specificCharacterSet = unpackMetaAsString(m_tagDict["0008|0005"]);
+      m_decoder = CharStringToUTF8Converter(specificCharacterSet);
       m_dirtyCache = false;
     }
 
@@ -101,7 +559,7 @@ public:
     for (auto it = m_tagDict.Begin(); it != m_tagDict.End(); ++it)
     {
       auto value = unpackMetaAsString(it->second);
-      allTagsDict[it->first] = value;
+      allTagsDict[it->first] = m_decoder.convertCharStringToUTF8(value);
     }
 
     return allTagsDict;
@@ -111,6 +569,7 @@ private:
   std::string               m_fileName;
   itk::GDCMImageIO::Pointer m_GDCMImageIO;
   MetaDictType              m_tagDict;
+  CharStringToUTF8Converter m_decoder = CharStringToUTF8Converter("");
   bool                      m_dirtyCache;
 };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,49 +78,56 @@ endforeach()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ImageIOIndex.js.in
   ${CMAKE_CURRENT_SOURCE_DIR}/ImageIOIndex.js @ONLY)
 
-# itkDICOMImageSeriesReader
+# DICOM-based readers
 find_package(ITK REQUIRED COMPONENTS ITKIOGDCM)
 include(${ITK_USE_FILE})
-set(target itkDICOMImageSeriesReaderJSBinding)
-set(wasm_target itkDICOMImageSeriesReaderJSBindingWasm)
-_add_executable(${target} Bindings/${target}.cxx)
-itk_module_target_label(${target})
-itk_module_target_export(${target})
-itk_module_target_install(${target})
-_add_executable(${wasm_target} Bindings/${target}.cxx)
-itk_module_target_label(${wasm_target})
-itk_module_target_export(${wasm_target})
-itk_module_target_install(${wasm_target})
-# For embind
-set_property(TARGET ${target} APPEND_STRING
-  PROPERTY LINK_FLAGS " --bind"
-  )
-set_property(TARGET ${wasm_target} APPEND_STRING
-  PROPERTY LINK_FLAGS " --bind"
-  )
-set_property(TARGET ${target} APPEND_STRING
-  PROPERTY LINK_FLAGS " -s DISABLE_EXCEPTION_CATCHING=0 -s WASM=0 -lnodefs.js -s FORCE_FILESYSTEM=1 -s EXIT_RUNTIME=0 -s INVOKE_RUN=0 --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSImageIOPre.js --post-js ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSPost.js"
-  )
-set(pre_js ${CMAKE_CURRENT_BINARY_DIR}/itkJSImageIOPreDICOMImageSeriesReader.js)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSImageIOPre.js.in
-  ${pre_js} @ONLY)
-set_property(TARGET ${wasm_target} APPEND_STRING
-  PROPERTY LINK_FLAGS " -s DISABLE_EXCEPTION_CATCHING=0 -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=itkDICOMImageSeriesReaderJSBinding -s WASM_ASYNC_COMPILATION=0 -s MODULARIZE=1 -s WASM=1 -lworkerfs.js -s EXIT_RUNTIME=0 -s INVOKE_RUN=0 --pre-js ${pre_js} --post-js ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSPost.js"
-  )
-set_property(TARGET ${target}
-  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-  ${BridgeJavaScript_BINARY_DIR}/ImageIOs
-  )
-set_property(TARGET ${wasm_target}
-  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-  ${BridgeJavaScript_BINARY_DIR}/ImageIOs
-  )
-set_property(SOURCE Bindings/${target}.cxx APPEND
-  PROPERTY OBJECT_DEPENDS
-  ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSPost.js
-  )
-_target_link_libraries(${target} LINK_PUBLIC ${ITK_LIBRARIES})
-_target_link_libraries(${wasm_target} LINK_PUBLIC ${ITK_LIBRARIES})
+foreach(dicom_io_module
+    itkDICOMImageSeriesReader
+    itkDICOMTagReader
+)
+  set(target "${dicom_io_module}JSBinding")
+  set(wasm_target "${dicom_io_module}JSBindingWasm")
+  _add_executable(${target} Bindings/${target}.cxx)
+  itk_module_target_label(${target})
+  itk_module_target_export(${target})
+  itk_module_target_install(${target})
+  _add_executable(${wasm_target} Bindings/${target}.cxx)
+  itk_module_target_label(${wasm_target})
+  itk_module_target_export(${wasm_target})
+  itk_module_target_install(${wasm_target})
+
+  # For embind
+  set_property(TARGET ${target} APPEND_STRING
+    PROPERTY LINK_FLAGS " --bind"
+    )
+  set_property(TARGET ${wasm_target} APPEND_STRING
+    PROPERTY LINK_FLAGS " --bind"
+    )
+  set_property(TARGET ${target} APPEND_STRING
+    PROPERTY LINK_FLAGS " -s DISABLE_EXCEPTION_CATCHING=0 -s WASM=0 -lnodefs.js -s FORCE_FILESYSTEM=1 -s EXIT_RUNTIME=0 -s INVOKE_RUN=0 --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSImageIOPre.js --post-js ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSPost.js"
+    )
+  set(pre_js "${CMAKE_CURRENT_BINARY_DIR}/itkJSImageIOPre${dicom_io_module}.js")
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSImageIOPre.js.in
+    ${pre_js} @ONLY)
+  set_property(TARGET ${wasm_target} APPEND_STRING
+    PROPERTY LINK_FLAGS " -s DISABLE_EXCEPTION_CATCHING=0 -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=${target} -s WASM_ASYNC_COMPILATION=0 -s MODULARIZE=1 -s WASM=1 -lworkerfs.js -s EXIT_RUNTIME=0 -s INVOKE_RUN=0 --pre-js ${pre_js} --post-js ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSPost.js"
+    )
+  set_property(TARGET ${target}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY
+    ${BridgeJavaScript_BINARY_DIR}/ImageIOs
+    )
+  set_property(TARGET ${wasm_target}
+    PROPERTY RUNTIME_OUTPUT_DIRECTORY
+    ${BridgeJavaScript_BINARY_DIR}/ImageIOs
+    )
+  set_property(SOURCE Bindings/${target}.cxx APPEND
+    PROPERTY OBJECT_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/EmscriptenModule/itkJSPost.js
+    )
+  _target_link_libraries(${target} LINK_PUBLIC ${ITK_LIBRARIES})
+  _target_link_libraries(${wasm_target} LINK_PUBLIC ${ITK_LIBRARIES})
+
+endforeach()
 
 set(MeshIOIndex_ARRAY "")
 foreach(io_module ${BridgeJavaScript_MeshIOModules})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,14 @@ find_path(RapidJSON_INCLUDE_DIR
   )
 include_directories(${RapidJSON_INCLUDE_DIR})
 
+# include iconv for reading dicom tags
+include(ExternalProject)
+set(Iconv iconv)
+set(Iconv_LIBRARY libiconv)
+set(Iconv_DIR ${CMAKE_BINARY_DIR}/libiconv)
+set(Iconv_INCLUDE_DIRS ${Iconv_DIR}/include)
+file(MAKE_DIRECTORY ${Iconv_DIR} ${Iconv_INCLUDE_DIRS})
+
 set(BridgeJavaScript_SRCS
   itkJSONImageIOFactory.cxx
   itkJSONImageIO.cxx
@@ -78,6 +86,34 @@ endforeach()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ImageIOIndex.js.in
   ${CMAKE_CURRENT_SOURCE_DIR}/ImageIOIndex.js @ONLY)
 
+
+# DICOM tag reading needs Iconv, and the docker image (currently)
+# used for building does not have iconv installed
+set(Iconv_CONFIGURE_COMMAND
+  emconfigure
+  ${Iconv_DIR}/src/libiconv/configure
+  --srcdir=${Iconv_DIR}/src/libiconv
+  --prefix=${Iconv_DIR}
+  --enable-static)
+set(Iconv_BUILD_COMMAND emmake make)
+
+ExternalProject_Add(${Iconv_LIBRARY}
+  PREFIX ${Iconv_DIR}
+  URL "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz"
+  URL_HASH SHA256=e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
+  CONFIGURE_COMMAND ${Iconv_CONFIGURE_COMMAND}
+  BUILD_COMMAND ${Iconv_BUILD_COMMAND}
+  # needed for ninja generator
+  BUILD_BYPRODUCTS ${Iconv_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}iconv${CMAKE_STATIC_LIBRARY_SUFFIX}
+)
+
+add_library(${Iconv} STATIC IMPORTED)
+set_target_properties(${Iconv} PROPERTIES
+  IMPORTED_LOCATION ${Iconv_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}iconv${CMAKE_STATIC_LIBRARY_SUFFIX}
+  INTERFACE_INCLUDE_DIRECTORIES ${Iconv_INCLUDE_DIRS})
+
+add_dependencies(${Iconv} ${Iconv_LIBRARY})
+
 # DICOM-based readers
 find_package(ITK REQUIRED COMPONENTS ITKIOGDCM)
 include(${ITK_USE_FILE})
@@ -127,6 +163,12 @@ foreach(dicom_io_module
   _target_link_libraries(${target} LINK_PUBLIC ${ITK_LIBRARIES})
   _target_link_libraries(${wasm_target} LINK_PUBLIC ${ITK_LIBRARIES})
 
+  # libiconv for DICOMTagReader
+  if(${dicom_io_module} STREQUAL "itkDICOMTagReader")
+    include_directories(${Iconv_INCLUDE_DIRS})
+    _target_link_libraries(${target} LINK_PUBLIC ${Iconv_LIBRARIES} ${Iconv})
+    _target_link_libraries(${wasm_target} LINK_PUBLIC ${Iconv_LIBRARIES} ${Iconv})
+  endif()
 endforeach()
 
 set(MeshIOIndex_ARRAY "")

--- a/src/readDICOMTags.js
+++ b/src/readDICOMTags.js
@@ -1,0 +1,32 @@
+import createWebworkerPromise from './createWebworkerPromise'
+import PromiseFileReader from 'promise-file-reader'
+
+import config from './itkConfig'
+
+const readDICOMTags = async (webWorker, file, tags = null) => {
+  let worker = webWorker
+  const { webworkerPromise, worker: usedWorker } = await createWebworkerPromise(
+    'ImageIO',
+    worker
+  )
+  worker = usedWorker
+  const arrayBuffer = await PromiseFileReader.readAsArrayBuffer(file)
+  try {
+    const tagValues = await webworkerPromise.postMessage(
+     {
+        operation: 'readDICOMTags',
+        name: file.name,
+        type: file.type,
+        data: arrayBuffer,
+        tags: tags,
+        config: config
+      },
+      [arrayBuffer]
+    )
+    return { tags: tagValues, webWorker: worker }
+  } catch (error) {
+    throw Error(error)
+  }
+}
+
+export default readDICOMTags

--- a/src/readDICOMTagsEmscriptenFSFile.js
+++ b/src/readDICOMTagsEmscriptenFSFile.js
@@ -1,0 +1,21 @@
+const readDICOMTagsEmscriptenFSFile = (tagReaderModule, fileName, tags = null) => {
+  const tagReader = new tagReaderModule.ITKDICOMTagReader()
+  tagReader.SetFileName(fileName)
+  const tagMap = new Map()
+  if (Array.isArray(tags)) {
+    for (let i = 0; i < tags.length; i++) {
+      const key = tags[i]
+      tagMap.set(key, tagReader.ReadTag(key.toLowerCase()))
+    }
+  } else {
+    const allTagsMap = tagReader.ReadAllTags()
+    const keys = allTagsMap.keys()
+    for (let i = 0; i < keys.size(); i++) {
+      const key = keys.get(i)
+      tagMap.set(key, allTagsMap.get(key))
+    }
+  }
+  return tagMap
+}
+
+module.exports = readDICOMTagsEmscriptenFSFile

--- a/src/readDICOMTagsLocalFile.js
+++ b/src/readDICOMTagsLocalFile.js
@@ -1,0 +1,13 @@
+const readDICOMTagsLocalFileSync = require('./readDICOMTagsLocalFileSync.js')
+
+const readDICOMTagsLocalFile = (filename, tags = null) => {
+  return new Promise(function (resolve, reject) {
+    try {
+      resolve(readDICOMTagsLocalFileSync(filename, tags))
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+module.exports = readDICOMTagsLocalFile

--- a/src/readDICOMTagsLocalFileSync.js
+++ b/src/readDICOMTagsLocalFileSync.js
@@ -1,0 +1,25 @@
+const path = require('path')
+
+const loadEmscriptenModule = require('./loadEmscriptenModuleNode.js')
+const readDICOMTagsEmscriptenFSFile = require('./readDICOMTagsEmscriptenFSFile.js')
+
+/**
+ * Reads DICOM tags from a series of DICOM files on the local filesystem in Node.js.
+ * @param: filename DICOM object filepath on the local filesystem.
+ * @param: tags Array of tags to extract.
+ */
+const readDICOMTagsLocalFileSync = (fileName, tags = null) => {
+  const imageIOsPath = path.resolve(__dirname, 'ImageIOs')
+  const tagReader = 'itkDICOMTagReaderJSBinding'
+  const tagReaderPath = path.join(imageIOsPath, tagReader)
+  const tagReaderModule = loadEmscriptenModule(tagReaderPath)
+  const mountedFilePath = tagReaderModule.mountContainingDirectory(fileName)
+  const mountedDir = path.dirname(mountedFilePath)
+  const mountedFileName = path.join(mountedDir, path.basename(fileName))
+  const result = readDICOMTagsEmscriptenFSFile(tagReaderModule,
+    mountedFileName, tags)
+  tagReaderModule.unmountContainingDirectory(mountedFilePath)
+  return result
+}
+
+module.exports = readDICOMTagsLocalFileSync

--- a/test/Browser/DICOMTest.js
+++ b/test/Browser/DICOMTest.js
@@ -4,6 +4,7 @@ import axios from 'axios'
 import IntTypes from 'IntTypes'
 import PixelTypes from 'PixelTypes'
 import readImageFile from 'readImageFile'
+import readDICOMTags from 'readDICOMTags'
 
 import getMatrixElement from 'getMatrixElement'
 
@@ -43,5 +44,36 @@ test('Test reading a DICOM file', t => {
       t.is(image.data.length, 65536, 'data.length')
       t.is(image.data[1000], 3, 'data[1000]')
       t.end()
+    })
+})
+
+test('Test reading DICOM tags', t => {
+  const expected = {
+    '0010|0020': 'NOID',
+    '0020|0032': '-3.295510e+01\\-1.339286e+02\\1.167857e+02',
+    '0020|0037': '0.00000e+00\\ 1.00000e+00\\-0.00000e+00\\-0.00000e+00\\ 0.00000e+00\\-1.00000e+00',
+    // case sensitivity test
+    '0008|103e': 'SAG/RF-FAST/VOL/FLIP 30 ',
+    '0008|103E': 'SAG/RF-FAST/VOL/FLIP 30 '
+  }
+  const fileName = '1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.100.0.dcm'
+  const testFilePath = 'base/build/ExternalData/test/Input/' + fileName
+  return axios.get(testFilePath, { responseType: 'blob' }).then(function (response) {
+    const jsFile = new window.File([response.data], fileName)
+    return jsFile
+  })
+    .then(function (jsFile) {
+      return readDICOMTags(null, jsFile, Object.keys(expected))
+    })
+    .then(function ({ tags: result, webWorker }) {
+      webWorker.terminate()
+      t.true(result instanceof Map)
+      Object.keys(expected).forEach((tag) => {
+        t.is(result.get(tag), expected[tag], tag)
+      })
+      t.end()
+    })
+    .catch((err) => {
+      t.fail(err)
     })
 })

--- a/test/DICOMTest.js
+++ b/test/DICOMTest.js
@@ -4,6 +4,7 @@ const path = require('path')
 const IntTypes = require(path.resolve(__dirname, '..', 'dist', 'IntTypes.js'))
 const PixelTypes = require(path.resolve(__dirname, '..', 'dist', 'PixelTypes.js'))
 const readImageLocalFile = require(path.resolve(__dirname, '..', 'dist', 'readImageLocalFile.js'))
+const readDICOMTagsLocalFileSync = require(path.resolve(__dirname, '..', 'dist', 'readDICOMTagsLocalFileSync.js'))
 
 test('Test reading a DICOM file', t => {
   const testFilePath = path.resolve(__dirname, '..', 'build', 'ExternalData', 'test', 'Input', '1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.100.0.dcm')
@@ -32,5 +33,23 @@ test('Test reading a DICOM file', t => {
     t.is(image.size[2], 1, 'size[2]')
     t.is(image.data.length, 65536, 'data.length')
     t.is(image.data[1000], 3, 'data[1000]')
+  })
+})
+
+test('Test reading DICOM tags', t => {
+  const testFilePath = path.resolve(__dirname, '..', 'build', 'ExternalData', 'test', 'Input', '1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.100.0.dcm')
+  const expected = {
+    '0010|0020': 'NOID',
+    '0020|0032': '-3.295510e+01\\-1.339286e+02\\1.167857e+02',
+    '0020|0037': '0.00000e+00\\ 1.00000e+00\\-0.00000e+00\\-0.00000e+00\\ 0.00000e+00\\-1.00000e+00',
+    // case sensitivity test
+    '0008|103e': 'SAG/RF-FAST/VOL/FLIP 30 ',
+    '0008|103E': 'SAG/RF-FAST/VOL/FLIP 30 '
+  }
+  const result = readDICOMTagsLocalFileSync(testFilePath, Object.keys(expected))
+
+  t.true(result instanceof Map)
+  Object.keys(expected).forEach((tag) => {
+    t.is(result.get(tag), expected[tag], tag)
   })
 })


### PR DESCRIPTION
This adds an API for reading DICOM tags from DICOM object files. Additionally, appropriate character set conversion is performed, decoding encoded strings into UTF-8.

Relevant issue: #394 

Todo:
- [x] add async version
- [x] add browser version
- [x] add charset decoder
- [x] Add docs
- [x] Make API and docs consistent