### PR TITLE
ENH: Add ITKTestingData gh-pages URL as primary CID source

### DIFF
--- a/CMake/ITKExternalData.cmake
+++ b/CMake/ITKExternalData.cmake
@@ -34,6 +34,11 @@ if(NOT ITK_FORBID_DOWNLOADS)
     # Local IPFS gateway
     "http://127.0.0.1:8080/ipfs/%(hash)"
 
+    # Primary CID source: ITKTestingData gh-pages mirror.
+    # %(algo) substitutes the uppercase algorithm name (CID, MD5, SHA512),
+    # matching the case-sensitive directory layout on the gh-pages branch.
+    "https://insightsoftwareconsortium.github.io/ITKTestingData/%(algo)/%(hash)"
+
     # Released data rsync'd to Kitware's Apache web server
     "https://itk.org/files/ExternalData/%(algo)/%(hash)"
 


### PR DESCRIPTION
Add the `ITKTestingData` gh-pages mirror as the primary remote source in `WebAssemblyInterface/CMake/ITKExternalData.cmake`, after the local IPFS gateway and ahead of itk.org / IPFS public gateways.

`%(algo)` substitutes the uppercase algorithm name, matching the case-sensitive `/CID/`, `/MD5/`, `/SHA512/` directory layout on the gh-pages branch (parallel to commit 317ab5fdaed2 on the ITK side).

<!-- claude-code 2026-04-29 phase3-ghpages-url -->
