### PR TITLE
fix(OutputImage): support information-only image outputs

### DIFF
--- a/include/itkOutputImage.h
+++ b/include/itkOutputImage.h
@@ -94,11 +94,6 @@ public:
         const auto dataSize = wasmImage->GetImage()->GetBufferedRegion().GetNumberOfPixels() *
                               sizeof(typename ConvertPixelTraits::ComponentType) *
                               wasmImage->GetImage()->GetNumberOfComponentsPerPixel();
-        if (dataSize <= 0)
-        {
-          std::cerr << "dataSize cannot be zero or negative." << std::endl;
-          abort();
-        }
         setMemoryStoreOutputArray(0, index, 0, dataAddress, dataSize);
 
         const auto directionAddress =

--- a/packages/core/python/itkwasm/itkwasm/pipeline.py
+++ b/packages/core/python/itkwasm/itkwasm/pipeline.py
@@ -462,7 +462,7 @@ class Pipeline:
                         image.imageType.componentType,
                         ri.wasmtime_lift(data_ptr, data_size),
                     )
-                    shape = list(image.size)[::-1]
+                    shape = list(image.bufferedRegion.size)[::-1]
                     if image.imageType.components > 1:
                         shape.append(image.imageType.components)
                     image.data = data_array.reshape(tuple(shape))

--- a/packages/core/python/itkwasm/itkwasm/pyodide.py
+++ b/packages/core/python/itkwasm/itkwasm/pyodide.py
@@ -83,7 +83,8 @@ def to_py(js_proxy):
         image_dict["direction"] = buffer_to_numpy_array(str(FloatTypes.Float64), image_dict["direction"]).reshape(
             (dimension, dimension)
         )
-        shape = list(image_dict["size"])[::-1]
+        buffered_region = image_dict.get("bufferedRegion")
+        shape = list(buffered_region["size"] if buffered_region is not None else image_dict["size"])[::-1]
         if image_type.components > 1:
             shape.append(image_type.components)
         if image_dict["data"] is not None:

--- a/packages/core/python/itkwasm/test/test_pipeline.py
+++ b/packages/core/python/itkwasm/test/test_pipeline.py
@@ -174,6 +174,56 @@ def test_pipeline_write_read_image():
     assert difference == 0.0
 
 
+def test_pipeline_information_only_image(monkeypatch):
+    import itkwasm.pipeline as pipeline_module
+
+    direction = np.eye(2, dtype=np.float64).tobytes()
+
+    class InformationOnlyRunInstance:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def delayed_start(self):
+            return 0
+
+        def get_output_json(self, output_index):
+            return {
+                "imageType": {
+                    "dimension": 2,
+                    "componentType": "uint8",
+                    "pixelType": "Scalar",
+                    "components": 1,
+                },
+                "size": [8, 8],
+                "bufferedRegion": {"index": [0, 0], "size": [0, 0]},
+            }
+
+        def get_output_array_address(self, memory, output_index, output_sub_index):
+            return output_sub_index
+
+        def get_output_array_size(self, memory, output_index, output_sub_index):
+            return 0 if output_sub_index == 0 else len(direction)
+
+        def wasmtime_lift(self, ptr, size):
+            return bytes() if size == 0 else direction
+
+        def delayed_exit(self, return_code):
+            pass
+
+    monkeypatch.setattr(pipeline_module, "RunInstance", InformationOnlyRunInstance)
+    pipeline = object.__new__(Pipeline)
+    pipeline.engine = None
+    pipeline.linker = None
+    pipeline.module = None
+
+    outputs = pipeline.run([], [PipelineOutput(InterfaceTypes.Image)])
+    image = outputs[0].data
+
+    assert image.size == [8, 8]
+    assert image.bufferedRegion.size == [0, 0]
+    assert image.data.shape == (0, 0)
+
+
 def test_pipeline_dask_array_input():
     pipeline = Pipeline(test_input_dir / "median-filter-test.wasi.wasm")
 

--- a/packages/core/python/itkwasm/test/test_pyodide.py
+++ b/packages/core/python/itkwasm/test/test_pyodide.py
@@ -22,7 +22,7 @@ file_list = [package_wheel(),]
 @copy_files_to_pyodide(file_list=file_list, install_wheels=True)
 @run_in_pyodide(packages=["numpy"])
 async def test_image_conversion(selenium):
-    from itkwasm import Image
+    from itkwasm import Image, ImageRegion
     from itkwasm.pyodide import to_js, to_py
     import numpy as np
 
@@ -72,6 +72,18 @@ async def test_image_conversion(selenium):
 
     assert isinstance(image_py.metadata, dict)
     assert np.array_equal(image_py.data, np.arange(16, dtype=np.uint8).reshape((4, 4)))
+
+    information_only_image = Image(
+        size=[4, 4],
+        bufferedRegion=ImageRegion(index=[0, 0], size=[0, 0]),
+        data=np.empty((0, 0), dtype=np.uint8),
+    )
+    information_only_image_py = to_py(to_js(information_only_image))
+
+    assert information_only_image_py.size == [4, 4]
+    assert information_only_image_py.bufferedRegion.size == [0, 0]
+    assert information_only_image_py.data.shape == (0, 0)
+
 
 @copy_files_to_pyodide(file_list=file_list, install_wheels=True)
 @run_in_pyodide(packages=["numpy"])

--- a/test/itkPipelineMemoryIOTest.cxx
+++ b/test/itkPipelineMemoryIOTest.cxx
@@ -367,6 +367,20 @@ itkPipelineMemoryIOTest(int argc, char * argv[])
 
   ITK_WASM_PARSE(pipeline);
 
+  auto                  informationOnlyImage = ImageType::New();
+  ImageType::RegionType informationOnlyRegion;
+  ImageType::SizeType   informationOnlySize;
+  informationOnlySize.Fill(8);
+  informationOnlyRegion.SetSize(informationOnlySize);
+  informationOnlyImage->SetLargestPossibleRegion(informationOnlyRegion);
+  {
+    OutputImageType informationOnlyOutput;
+    informationOnlyOutput.SetIdentifier("9");
+    informationOnlyOutput.Set(informationOnlyImage);
+  }
+  ITK_TEST_EXPECT_EQUAL(itk_wasm_output_array_address(0, 9, 0), 0);
+  ITK_TEST_EXPECT_EQUAL(itk_wasm_output_array_size(0, 9, 0), 0);
+
   outputImage.Set(inputImage.Get());
 
   const std::string inputTextStreamContent{ std::istreambuf_iterator<char>(inputTextStream.Get()),


### PR DESCRIPTION
## Summary

- allow memory-I/O image outputs with an empty buffered region
- reshape Python image data from `bufferedRegion.size` while preserving the
  largest possible image `size`
- apply the same buffered-region reconstruction in Pyodide
- add native, Python runtime, and Pyodide regression coverage

## Context

`downsample_bin_shrink(..., information_only=True)` calls
`UpdateOutputInformation()` and intentionally produces output metadata without
allocating a pixel buffer. `OutputImage` currently aborts when that legitimate
buffer has zero bytes. After removing the abort, the Python runtime also needs
to reshape data from the buffered region rather than the largest possible
region; otherwise it attempts to reshape an empty array to the logical image
size.

This breaks the metadata pre-pass used by `itkwasm-downsample-cucim==0.2.0`
for Gaussian and bin-shrink downsampling.

Downstream report: https://github.com/fideus-labs/ngff-zarr/issues/577

## Validation

- core Python tests excluding browser-only tests: **28 passed, 2 skipped**
- focused native `itkPipelineMemoryIOTest`: **passed**
- C++ files pass `clang-format --dry-run --Werror`
- full native build reached and compiled the modified test, but the aggregate
  target was blocked by an unavailable pre-existing external test object:
  `TransformSequence.h5`
- WASI package rebuild was not available locally because Docker/Podman is not
  installed
- the Pyodide wheel built successfully, but all browser tests were blocked at
  setup because the local Chrome instance exited before creating a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
