### PR TITLE
fix(image-io): support 32-bit integer TIFF read/write

### DIFF
--- a/packages/image-io/typescript/test/node/tiff-test.js
+++ b/packages/image-io/typescript/test/node/tiff-test.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import path from 'path'
 
 import { tiffReadImageNode, tiffWriteImageNode } from '../../dist/index-node.js'
-import { IntTypes, PixelTypes, getMatrixElement, Image, ImageType } from 'itk-wasm'
+import { IntTypes, PixelTypes, getMatrixElement } from 'itk-wasm'
 
 import { testInputPath, testOutputPath } from './common.js'
 
@@ -44,40 +44,4 @@ test('Test writing a TIFF file', async t => {
   const { couldRead: couldReadBack, image: imageBack } = await tiffReadImageNode(testOutputFilePath)
   t.true(couldReadBack)
   verifyImage(t, imageBack)
-})
-
-// Round-trip a scalar image whose component type is written and read back with
-// full fidelity. Sample values intentionally exceed the 16-bit range so the
-// 32-bit integer cases genuinely exercise 32-bit storage.
-const roundTripScalar = async (t, componentType, TypedArrayConstructor, sample) => {
-  const dimension = 2
-  const size = [4, 3]
-  const image = new Image(new ImageType(dimension, componentType, PixelTypes.Scalar, 1))
-  image.size = size
-  const length = size[0] * size[1]
-  image.data = new TypedArrayConstructor(length)
-  for (let index = 0; index < length; index++) {
-    image.data[index] = sample(index)
-  }
-
-  const outputFilePath = path.join(testOutputPath, `tiff-roundtrip-${componentType}.tiff`)
-  const { couldWrite } = await tiffWriteImageNode(image, outputFilePath)
-  t.true(couldWrite, `couldWrite ${componentType}`)
-
-  const { couldRead, image: imageBack } = await tiffReadImageNode(outputFilePath)
-  t.true(couldRead, `couldRead ${componentType}`)
-  t.is(imageBack.imageType.componentType, componentType, 'componentType')
-  t.is(imageBack.data.length, length, 'data.length')
-  for (let index = 0; index < length; index++) {
-    t.is(Number(imageBack.data[index]), Number(image.data[index]), `data[${index}]`)
-  }
-}
-
-// https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1544
-test('Round-trip a uint32 scalar TIFF file', async t => {
-  await roundTripScalar(t, IntTypes.UInt32, Uint32Array, index => (index * 100003 + 70000) >>> 0)
-})
-
-test('Round-trip an int32 scalar TIFF file', async t => {
-  await roundTripScalar(t, IntTypes.Int32, Int32Array, index => (index % 2 ? -1 : 1) * (index * 100003 + 70000))
 })

--- a/packages/image-io/typescript/test/node/tiff-test.js
+++ b/packages/image-io/typescript/test/node/tiff-test.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import path from 'path'
 
 import { tiffReadImageNode, tiffWriteImageNode } from '../../dist/index-node.js'
-import { IntTypes, PixelTypes, getMatrixElement } from 'itk-wasm'
+import { IntTypes, PixelTypes, getMatrixElement, Image, ImageType } from 'itk-wasm'
 
 import { testInputPath, testOutputPath } from './common.js'
 
@@ -44,4 +44,40 @@ test('Test writing a TIFF file', async t => {
   const { couldRead: couldReadBack, image: imageBack } = await tiffReadImageNode(testOutputFilePath)
   t.true(couldReadBack)
   verifyImage(t, imageBack)
+})
+
+// Round-trip a scalar image whose component type is written and read back with
+// full fidelity. Sample values intentionally exceed the 16-bit range so the
+// 32-bit integer cases genuinely exercise 32-bit storage.
+const roundTripScalar = async (t, componentType, TypedArrayConstructor, sample) => {
+  const dimension = 2
+  const size = [4, 3]
+  const image = new Image(new ImageType(dimension, componentType, PixelTypes.Scalar, 1))
+  image.size = size
+  const length = size[0] * size[1]
+  image.data = new TypedArrayConstructor(length)
+  for (let index = 0; index < length; index++) {
+    image.data[index] = sample(index)
+  }
+
+  const outputFilePath = path.join(testOutputPath, `tiff-roundtrip-${componentType}.tiff`)
+  const { couldWrite } = await tiffWriteImageNode(image, outputFilePath)
+  t.true(couldWrite, `couldWrite ${componentType}`)
+
+  const { couldRead, image: imageBack } = await tiffReadImageNode(outputFilePath)
+  t.true(couldRead, `couldRead ${componentType}`)
+  t.is(imageBack.imageType.componentType, componentType, 'componentType')
+  t.is(imageBack.data.length, length, 'data.length')
+  for (let index = 0; index < length; index++) {
+    t.is(Number(imageBack.data[index]), Number(image.data[index]), `data[${index}]`)
+  }
+}
+
+// https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1544
+test('Round-trip a uint32 scalar TIFF file', async t => {
+  await roundTripScalar(t, IntTypes.UInt32, Uint32Array, index => (index * 100003 + 70000) >>> 0)
+})
+
+test('Round-trip an int32 scalar TIFF file', async t => {
+  await roundTripScalar(t, IntTypes.Int32, Int32Array, index => (index % 2 ? -1 : 1) * (index * 100003 + 70000))
 })

--- a/src/docker/itk-wasm-base/Dockerfile
+++ b/src/docker/itk-wasm-base/Dockerfile
@@ -39,6 +39,9 @@ RUN curl -L https://api.github.com/repos/facebook/zstd/tarball/${zstd_GIT_TAG} |
 ARG USE_LOCAL_ITK=0
 COPY ITKLocalCopy /ITKLocalCopy
 
+# ITK source patches applied on top of $ITK_WASM_ITK_BRANCH.
+COPY patches /itk-wasm-patches
+
 # Either use local ITK source or clone from git repository
 RUN . /itk_wasm_env_vars.sh && \
   if [ "$USE_LOCAL_ITK" = "1" ] && [ -d /ITKLocalCopy ] && [ "$(ls -A /ITKLocalCopy 2>/dev/null | grep -v .gitkeep)" ]; then \
@@ -51,6 +54,17 @@ RUN . /itk_wasm_env_vars.sh && \
   fi && \
   sed -i -e '/^option(OPJ_USE_THREAD/c\option(OPJ_USE_THREAD "use threads" OFF)' \
     /ITK/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/src/lib/openjp2/CMakeLists.txt
+
+# Apply ITK source patches (idempotent, so a local ITK that already carries a
+# fix is left untouched). Remove a patch here once it lands in $ITK_WASM_ITK_BRANCH.
+RUN cd /ITK && for patch in /itk-wasm-patches/*.patch; do \
+    [ -e "$patch" ] || continue; \
+    if git apply --reverse --check "$patch" 2>/dev/null; then \
+      echo "Skipping already-applied patch: $patch"; \
+    else \
+      echo "Applying patch: $patch" && git apply --verbose "$patch"; \
+    fi; \
+  done
 
 # Modify CMake variable to use patched DCMTK library
 # GIT_TAG refers to DCMTK branch: 20240311_DCMTK_PATCHES_FOR_ITK-Wasm-1

--- a/src/docker/itk-wasm-base/patches/README.md
+++ b/src/docker/itk-wasm-base/patches/README.md
@@ -1,0 +1,27 @@
+# ITK source patches
+
+Unified diffs in this directory are applied to the ITK source tree while the
+`itkwasm/emscripten-base` image is built (see the `git apply` step in
+[`../Dockerfile`](../Dockerfile)). They sit on top of the ITK revision pinned
+by `ITK_WASM_ITK_REPOSITORY` / `ITK_WASM_ITK_BRANCH` in
+[`../../../../itk_wasm_env.bash`](../../../../itk_wasm_env.bash).
+
+Application is idempotent: a patch that is already present in the source tree
+(for example, a local ITK checkout used with `USE_LOCAL_ITK=1`) is detected with
+`git apply --reverse --check` and skipped.
+
+Each patch is a `git format-patch` file, so it can also be applied with
+`git am` and submitted upstream. Remove a patch from this directory once the
+change is merged into the pinned ITK branch.
+
+## Patches
+
+- `itk-tiff-uint32-int32.patch` — teach `itk::TIFFImageIO` to read and write
+  32-bit integer (`uint32` / `int32`) images. Without it, writing such an image
+  throws (aborting the WebAssembly module) and reading one silently yields a
+  zero-filled buffer, even though the component types are advertised as
+  supported. Fixes
+  [ITK-Wasm#1544](https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1544).
+  Submitted upstream as
+  [ITK#6541](https://github.com/InsightSoftwareConsortium/ITK/pull/6541); remove
+  this patch once that change is in the pinned ITK branch.

--- a/src/docker/itk-wasm-base/patches/itk-tiff-uint32-int32.patch
+++ b/src/docker/itk-wasm-base/patches/itk-tiff-uint32-int32.patch
@@ -1,4 +1,4 @@
-From 1f3573abfa0726ae26ec6376a5e8fbcc798cd5b8 Mon Sep 17 00:00:00 2001
+From b9a1b03e58c064c1609580fbffbfb4ddbee72fcb Mon Sep 17 00:00:00 2001
 From: Matt McCormick <matt@fideus.io>
 Date: Thu, 2 Jul 2026 15:26:09 -0400
 Subject: [PATCH] BUG: Support reading and writing 32-bit integer TIFF images
@@ -23,6 +23,12 @@ the write (bits-per-sample, sample-format, and row-length) and read (component
 dispatch) paths. The multi-page reader branch uses a correctly typed pointer so
 the per-page pixel offset arithmetic stays correct.
 
+Also set SAMPLEFORMAT_UINT explicitly for the unsigned 8- and 16-bit cases
+(UCHAR/USHORT). These previously relied on libtiff's default sample format,
+which is also SAMPLEFORMAT_UINT, so this is behavior-preserving (verified: the
+byte-exact --compare-MD5 tests are unchanged) but makes the signed / unsigned /
+float grouping explicit and self-documenting.
+
 Add itkTIFFImageIOInt32Test, a GoogleTest that round-trips uint32 and int32
 images with values exceeding the 16-bit range in both 2-D and multi-page (3-D)
 TIFFs, asserting both the on-disk component type and full-fidelity pixel values.
@@ -32,11 +38,11 @@ Reported at https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1544
 Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 Signed-off-by: Matt McCormick <matt@fideus.io>
 ---
- Modules/IO/TIFF/src/itkTIFFImageIO.cxx | 48 +++++++++++++++++++++++---
- 1 file changed, 44 insertions(+), 4 deletions(-)
+ Modules/IO/TIFF/src/itkTIFFImageIO.cxx | 50 +++++++++++++++++++++++---
+ 1 file changed, 46 insertions(+), 4 deletions(-)
 
 diff --git a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
-index feaffc0bc2..c76ab30232 100644
+index feaffc0bc2..02cdee6a41 100644
 --- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
 +++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
 @@ -72,6 +72,14 @@ TIFFImageIO::ReadGenericImage(void * out, unsigned int width, unsigned int heigh
@@ -72,7 +78,7 @@ index feaffc0bc2..c76ab30232 100644
    }
  
    uint16_t predictor;
-@@ -638,10 +651,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
+@@ -638,10 +651,16 @@ TIFFImageIO::InternalWrite(const void * buffer)
                                                                        << itksys::SystemTools::GetLastSystemError());
    }
  
@@ -82,14 +88,15 @@ index feaffc0bc2..c76ab30232 100644
    {
      TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_INT);
    }
-+  else if (this->GetComponentType() == IOComponentEnum::UINT)
++  else if (this->GetComponentType() == IOComponentEnum::UCHAR || this->GetComponentType() == IOComponentEnum::USHORT ||
++           this->GetComponentType() == IOComponentEnum::UINT)
 +  {
 +    TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
 +  }
    else if (this->GetComponentType() == IOComponentEnum::FLOAT)
    {
      TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
-@@ -663,10 +681,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
+@@ -663,10 +682,16 @@ TIFFImageIO::InternalWrite(const void * buffer)
      TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, scomponents);
      TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bps); // Fix for stype
      TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
@@ -99,14 +106,15 @@ index feaffc0bc2..c76ab30232 100644
      {
        TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_INT);
      }
-+    else if (this->GetComponentType() == IOComponentEnum::UINT)
++    else if (this->GetComponentType() == IOComponentEnum::UCHAR ||
++             this->GetComponentType() == IOComponentEnum::USHORT || this->GetComponentType() == IOComponentEnum::UINT)
 +    {
 +      TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
 +    }
      else if (this->GetComponentType() == IOComponentEnum::FLOAT)
      {
        TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
-@@ -814,11 +837,16 @@ TIFFImageIO::InternalWrite(const void * buffer)
+@@ -814,11 +839,16 @@ TIFFImageIO::InternalWrite(const void * buffer)
        case IOComponentEnum::SHORT:
          rowLength = sizeof(short);
          break;
@@ -124,7 +132,7 @@ index feaffc0bc2..c76ab30232 100644
      }
  
      rowLength *= this->GetNumberOfComponents();
-@@ -1330,6 +1358,18 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
+@@ -1330,6 +1360,18 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
        volume += pixelOffset;
        this->ReadGenericImage(volume, width, height);
      }

--- a/src/docker/itk-wasm-base/patches/itk-tiff-uint32-int32.patch
+++ b/src/docker/itk-wasm-base/patches/itk-tiff-uint32-int32.patch
@@ -1,34 +1,42 @@
-From e9d5280ab45ed82550bde6c81a920774ba0fd1b9 Mon Sep 17 00:00:00 2001
+From 1f3573abfa0726ae26ec6376a5e8fbcc798cd5b8 Mon Sep 17 00:00:00 2001
 From: Matt McCormick <matt@fideus.io>
-Date: Thu, 2 Jul 2026 18:57:57 +0000
-Subject: [PATCH] BUG: Support reading and writing 32-bit integer
- (uint32/int32) TIFF images
+Date: Thu, 2 Jul 2026 15:26:09 -0400
+Subject: [PATCH] BUG: Support reading and writing 32-bit integer TIFF images
 
-itk::TIFFImageIO advertised uint32/int32 as supported component types and
-its metadata reader already mapped 32-bit samples with SAMPLEFORMAT_UINT
-and SAMPLEFORMAT_INT to IOComponentEnum::UINT / ::INT.  However:
+itk::TIFFImageIO advertised uint32/int32 as supported component types, and
+its metadata reader already mapped 32-bit samples with SAMPLEFORMAT_UINT and
+SAMPLEFORMAT_INT to IOComponentEnum::UINT / IOComponentEnum::INT. However, the
+pixel paths did not handle these types:
 
-* InternalWrite() only handled 8-/16-bit integers and 32-bit float, so
-  writing a uint32 or int32 image threw an itk::ExceptionObject
-  ("TIFF supports unsigned/signed char, unsigned/signed short, and
-  float").  In WebAssembly builds this surfaced to callers as an
-  unrecoverable abort.
+* InternalWrite() only handled 8-/16-bit integers and 32-bit float, so writing
+  a uint32 or int32 image threw an itk::ExceptionObject ("TIFF supports
+  unsigned/signed char, unsigned/signed short, and float"). In WebAssembly
+  builds this surfaced to callers as an unrecoverable abort.
 
-* The pixel-reading dispatch in ReadGenericImage(void*, ...) and
-  ReadCurrentPage() had no UINT/INT case, so reading a 32-bit integer
-  TIFF silently left the output buffer zero-filled.
+* The pixel-reading dispatch in ReadGenericImage(void *, ...) and
+  ReadCurrentPage() had no UINT/INT case, so reading a 32-bit integer TIFF
+  silently left the output buffer zero-filled.
 
-libtiff fully supports 32-bit integer samples (BITSPERSAMPLE=32 with
-SAMPLEFORMAT_UINT / SAMPLEFORMAT_INT), so add the missing UINT and INT
-cases to the write (bits-per-sample, sample-format and row-length) and
-read (component dispatch) paths.  uint32/int32 images now round-trip
-with full 32-bit fidelity in both 2-D and multi-page (3-D) TIFFs.
+libtiff fully supports 32-bit integer samples (BITSPERSAMPLE = 32 with
+SAMPLEFORMAT_UINT / SAMPLEFORMAT_INT), so add the missing UINT and INT cases to
+the write (bits-per-sample, sample-format, and row-length) and read (component
+dispatch) paths. The multi-page reader branch uses a correctly typed pointer so
+the per-page pixel offset arithmetic stays correct.
+
+Add itkTIFFImageIOInt32Test, a GoogleTest that round-trips uint32 and int32
+images with values exceeding the 16-bit range in both 2-D and multi-page (3-D)
+TIFFs, asserting both the on-disk component type and full-fidelity pixel values.
+
+Reported at https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1544
+
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Signed-off-by: Matt McCormick <matt@fideus.io>
 ---
- Modules/IO/TIFF/src/itkTIFFImageIO.cxx | 52 ++++++++++++++++++++++++--
- 1 file changed, 48 insertions(+), 4 deletions(-)
+ Modules/IO/TIFF/src/itkTIFFImageIO.cxx | 48 +++++++++++++++++++++++---
+ 1 file changed, 44 insertions(+), 4 deletions(-)
 
 diff --git a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
-index 37df52e..b4ca55e 100644
+index feaffc0bc2..c76ab30232 100644
 --- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
 +++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
 @@ -72,6 +72,14 @@ TIFFImageIO::ReadGenericImage(void * out, unsigned int width, unsigned int heigh
@@ -46,13 +54,11 @@ index 37df52e..b4ca55e 100644
    else if (m_ComponentType == IOComponentEnum::FLOAT)
    {
      this->ReadGenericImage<float>(out, width, height);
-@@ -600,11 +608,18 @@ TIFFImageIO::InternalWrite(const void * buffer)
+@@ -603,11 +611,16 @@ TIFFImageIO::InternalWrite(const void * buffer)
      case IOComponentEnum::SHORT:
        bps = 16;
        break;
 +    case IOComponentEnum::UINT:
-+      bps = 32;
-+      break;
 +    case IOComponentEnum::INT:
 +      bps = 32;
 +      break;
@@ -66,7 +72,7 @@ index 37df52e..b4ca55e 100644
    }
  
    uint16_t predictor;
-@@ -635,10 +650,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
+@@ -638,10 +651,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
                                                                        << itksys::SystemTools::GetLastSystemError());
    }
  
@@ -83,7 +89,7 @@ index 37df52e..b4ca55e 100644
    else if (this->GetComponentType() == IOComponentEnum::FLOAT)
    {
      TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
-@@ -660,10 +680,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
+@@ -663,10 +681,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
      TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, scomponents);
      TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bps); // Fix for stype
      TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
@@ -100,15 +106,13 @@ index 37df52e..b4ca55e 100644
      else if (this->GetComponentType() == IOComponentEnum::FLOAT)
      {
        TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
-@@ -811,11 +836,18 @@ TIFFImageIO::InternalWrite(const void * buffer)
+@@ -814,11 +837,16 @@ TIFFImageIO::InternalWrite(const void * buffer)
        case IOComponentEnum::SHORT:
          rowLength = sizeof(short);
          break;
 +      case IOComponentEnum::UINT:
-+        rowLength = sizeof(unsigned int);
-+        break;
 +      case IOComponentEnum::INT:
-+        rowLength = sizeof(int);
++        rowLength = sizeof(unsigned int);
 +        break;
        case IOComponentEnum::FLOAT:
          rowLength = sizeof(float);
@@ -120,7 +124,7 @@ index 37df52e..b4ca55e 100644
      }
  
      rowLength *= this->GetNumberOfComponents();
-@@ -1327,6 +1359,18 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
+@@ -1330,6 +1358,18 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
        volume += pixelOffset;
        this->ReadGenericImage(volume, width, height);
      }
@@ -140,5 +144,5 @@ index 37df52e..b4ca55e 100644
      {
        auto * volume = static_cast<char *>(buffer);
 -- 
-2.42.0
+2.43.0
 

--- a/src/docker/itk-wasm-base/patches/itk-tiff-uint32-int32.patch
+++ b/src/docker/itk-wasm-base/patches/itk-tiff-uint32-int32.patch
@@ -1,0 +1,144 @@
+From e9d5280ab45ed82550bde6c81a920774ba0fd1b9 Mon Sep 17 00:00:00 2001
+From: Matt McCormick <matt@fideus.io>
+Date: Thu, 2 Jul 2026 18:57:57 +0000
+Subject: [PATCH] BUG: Support reading and writing 32-bit integer
+ (uint32/int32) TIFF images
+
+itk::TIFFImageIO advertised uint32/int32 as supported component types and
+its metadata reader already mapped 32-bit samples with SAMPLEFORMAT_UINT
+and SAMPLEFORMAT_INT to IOComponentEnum::UINT / ::INT.  However:
+
+* InternalWrite() only handled 8-/16-bit integers and 32-bit float, so
+  writing a uint32 or int32 image threw an itk::ExceptionObject
+  ("TIFF supports unsigned/signed char, unsigned/signed short, and
+  float").  In WebAssembly builds this surfaced to callers as an
+  unrecoverable abort.
+
+* The pixel-reading dispatch in ReadGenericImage(void*, ...) and
+  ReadCurrentPage() had no UINT/INT case, so reading a 32-bit integer
+  TIFF silently left the output buffer zero-filled.
+
+libtiff fully supports 32-bit integer samples (BITSPERSAMPLE=32 with
+SAMPLEFORMAT_UINT / SAMPLEFORMAT_INT), so add the missing UINT and INT
+cases to the write (bits-per-sample, sample-format and row-length) and
+read (component dispatch) paths.  uint32/int32 images now round-trip
+with full 32-bit fidelity in both 2-D and multi-page (3-D) TIFFs.
+---
+ Modules/IO/TIFF/src/itkTIFFImageIO.cxx | 52 ++++++++++++++++++++++++--
+ 1 file changed, 48 insertions(+), 4 deletions(-)
+
+diff --git a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+index 37df52e..b4ca55e 100644
+--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
++++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+@@ -72,6 +72,14 @@ TIFFImageIO::ReadGenericImage(void * out, unsigned int width, unsigned int heigh
+   {
+     this->ReadGenericImage<short>(out, width, height);
+   }
++  else if (m_ComponentType == IOComponentEnum::UINT)
++  {
++    this->ReadGenericImage<unsigned int>(out, width, height);
++  }
++  else if (m_ComponentType == IOComponentEnum::INT)
++  {
++    this->ReadGenericImage<int>(out, width, height);
++  }
+   else if (m_ComponentType == IOComponentEnum::FLOAT)
+   {
+     this->ReadGenericImage<float>(out, width, height);
+@@ -600,11 +608,18 @@ TIFFImageIO::InternalWrite(const void * buffer)
+     case IOComponentEnum::SHORT:
+       bps = 16;
+       break;
++    case IOComponentEnum::UINT:
++      bps = 32;
++      break;
++    case IOComponentEnum::INT:
++      bps = 32;
++      break;
+     case IOComponentEnum::FLOAT:
+       bps = 32;
+       break;
+     default:
+-      itkExceptionMacro("TIFF supports unsigned/signed char, unsigned/signed short, and float");
++      itkExceptionMacro(
++        "TIFF supports unsigned/signed char, unsigned/signed short, unsigned/signed int (32-bit), and float");
+   }
+ 
+   uint16_t predictor;
+@@ -635,10 +650,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
+                                                                       << itksys::SystemTools::GetLastSystemError());
+   }
+ 
+-  if (this->GetComponentType() == IOComponentEnum::SHORT || this->GetComponentType() == IOComponentEnum::CHAR)
++  if (this->GetComponentType() == IOComponentEnum::SHORT || this->GetComponentType() == IOComponentEnum::CHAR ||
++      this->GetComponentType() == IOComponentEnum::INT)
+   {
+     TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_INT);
+   }
++  else if (this->GetComponentType() == IOComponentEnum::UINT)
++  {
++    TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
++  }
+   else if (this->GetComponentType() == IOComponentEnum::FLOAT)
+   {
+     TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
+@@ -660,10 +680,15 @@ TIFFImageIO::InternalWrite(const void * buffer)
+     TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, scomponents);
+     TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bps); // Fix for stype
+     TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+-    if (this->GetComponentType() == IOComponentEnum::SHORT || this->GetComponentType() == IOComponentEnum::CHAR)
++    if (this->GetComponentType() == IOComponentEnum::SHORT || this->GetComponentType() == IOComponentEnum::CHAR ||
++        this->GetComponentType() == IOComponentEnum::INT)
+     {
+       TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_INT);
+     }
++    else if (this->GetComponentType() == IOComponentEnum::UINT)
++    {
++      TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
++    }
+     else if (this->GetComponentType() == IOComponentEnum::FLOAT)
+     {
+       TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
+@@ -811,11 +836,18 @@ TIFFImageIO::InternalWrite(const void * buffer)
+       case IOComponentEnum::SHORT:
+         rowLength = sizeof(short);
+         break;
++      case IOComponentEnum::UINT:
++        rowLength = sizeof(unsigned int);
++        break;
++      case IOComponentEnum::INT:
++        rowLength = sizeof(int);
++        break;
+       case IOComponentEnum::FLOAT:
+         rowLength = sizeof(float);
+         break;
+       default:
+-        itkExceptionMacro("TIFF supports unsigned/signed char, unsigned/signed short, and float");
++        itkExceptionMacro(
++          "TIFF supports unsigned/signed char, unsigned/signed short, unsigned/signed int (32-bit), and float");
+     }
+ 
+     rowLength *= this->GetNumberOfComponents();
+@@ -1327,6 +1359,18 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
+       volume += pixelOffset;
+       this->ReadGenericImage(volume, width, height);
+     }
++    else if (m_ComponentType == IOComponentEnum::UINT)
++    {
++      auto * volume = static_cast<unsigned int *>(buffer);
++      volume += pixelOffset;
++      this->ReadGenericImage(volume, width, height);
++    }
++    else if (m_ComponentType == IOComponentEnum::INT)
++    {
++      auto * volume = static_cast<int *>(buffer);
++      volume += pixelOffset;
++      this->ReadGenericImage(volume, width, height);
++    }
+     else if (m_ComponentType == IOComponentEnum::CHAR)
+     {
+       auto * volume = static_cast<char *>(buffer);
+-- 
+2.42.0
+


### PR DESCRIPTION
## Summary

Fixes #1544 — `writeImageNode` / `writeImage` crashed when given a `Uint32Array` (component type `uint32`), while `uint8`/`uint16` worked.

Root cause is in ITK's `itk::TIFFImageIO` (which ITK-Wasm builds from the pinned `thewtex/ITK` branch). Although `uint32`/`int32` are advertised as supported component types and the TIFF metadata reader maps 32-bit samples to `IOComponentEnum::UINT`/`::INT`, the pixel paths did not handle them:

- **Write** threw `itk::ExceptionObject` for `uint32`/`int32`, which surfaced to JS as an unrecoverable WASM abort (the raw exception-pointer number in the issue).
- **Read** had no `UINT`/`INT` dispatch case, so a 32-bit-integer TIFF read back as a zero-filled buffer.

Other formats (MetaImage, NRRD, NIfTI, VTK) already round-trip `uint32` fine; this was TIFF-specific (`uint32` **and** `int32`).

## Changes

- **`src/docker/itk-wasm-base/patches/itk-tiff-uint32-int32.patch`** — ITK source fix adding the missing `UINT`/`INT` cases to `TIFFImageIO`'s write (bits-per-sample, `SAMPLEFORMAT`, row-length) and read (component dispatch) paths. Formatted as a `git format-patch` so it can also be applied with `git am`.
- **`src/docker/itk-wasm-base/Dockerfile`** — apply `patches/*.patch` to the ITK source after checkout, via an idempotent `git apply` loop (reverse-check skips an already-applied patch, so a local ITK with the fix — `USE_LOCAL_ITK=1` — is left untouched).
- **`src/docker/itk-wasm-base/patches/README.md`** — documents the patch mechanism.
- **`packages/image-io/typescript/test/node/tiff-test.js`** — `uint32` and `int32` TIFF round-trip regression tests (values exceed the 16-bit range to exercise real 32-bit storage).

## Upstream

The same fix is submitted to ITK: InsightSoftwareConsortium/ITK#6541. The patch here is a stopgap and should be removed once that lands in the pinned ITK branch. **Reaching users requires rebuilding and republishing the `emscripten-base` / `emscripten` images** (the fix rebuilds ITK).

## Testing

Verified end-to-end with a targeted ITK + pipeline rebuild against the patched source: the original issue reproduction now succeeds, written TIFFs are byte-correct (`BitsPerSample=32`), and `uint32`/`int32` round-trip with full 32-bit fidelity (values up to ~1.17M) in both 2-D and 3-D (multi-page), with no regression on `uint8`/`int16`/`float32`. Upstream, the ITK TIFF `ctest` suite passes 64/64 including 4 new cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
