### PR TITLE
fix(image-io): preserve original DICOM Study/Series UIDs on GDCM write (#1470)

### DIFF
--- a/packages/image-io/python/itkwasm-image-io-wasi/tests/test_gdcm_preserve_uid.py
+++ b/packages/image-io/python/itkwasm-image-io-wasi/tests/test_gdcm_preserve_uid.py
@@ -1,0 +1,55 @@
+from itkwasm_image_io_wasi import gdcm_read_image, gdcm_write_image
+
+from .common import test_input_path, test_output_path
+
+# Issue #1470: itk::GDCMImageIO regenerates the StudyInstanceUID (0020|000d) and
+# SeriesInstanceUID (0020|000e) on write unless KeepOriginalUID is set. The fix in
+# write-image.cxx enables SetKeepOriginalUID(true) when the input metadata already
+# carries these tags, so the original Study/Series UIDs survive a write instead of
+# being regenerated. This is the Python/WASI mirror of the authoritative Node test
+# (gdcm-preserve-uid-test.js from Phase 03).
+# Refs: https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1470
+
+test_input_file_path = test_input_path / '1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.100.0.dcm'
+test_output_file_path = test_output_path / 'test_gdcm_preserve_uid.dcm'
+
+study_instance_uid_tag = '0020|000d'
+series_instance_uid_tag = '0020|000e'
+
+
+def test_gdcm_preserve_uid_read_precondition():
+    # The fix keys off the presence of Study/Series Instance UIDs in the input
+    # metadata, so first confirm the sample actually carries non-empty values for
+    # both tags. Without this precondition the round-trip test below could pass
+    # vacuously.
+    could_read, image = gdcm_read_image(test_input_file_path)
+    assert could_read
+    assert image.metadata.get(study_instance_uid_tag), \
+        'sample DICOM must carry a non-empty StudyInstanceUID (0020|000d)'
+    assert image.metadata.get(series_instance_uid_tag), \
+        'sample DICOM must carry a non-empty SeriesInstanceUID (0020|000e)'
+
+
+def test_gdcm_preserve_uid_round_trip():
+    # Read the sample, write it back out through the fixed gdcm-write wasm
+    # (uncompressed), read the written file back, and assert the Study/Series UIDs
+    # are byte-for-byte identical across the round-trip. A mismatch means GDCM
+    # regenerated the UID on write instead of preserving it (the pre-fix bug #1470).
+    could_read, image = gdcm_read_image(test_input_file_path)
+    assert could_read
+
+    original_study = image.metadata[study_instance_uid_tag]
+    original_series = image.metadata[series_instance_uid_tag]
+
+    could_write = gdcm_write_image(image, str(test_output_file_path), use_compression=False)
+    assert could_write
+
+    could_read_back, image_back = gdcm_read_image(test_output_file_path)
+    assert could_read_back
+
+    assert image_back.metadata[study_instance_uid_tag] == original_study, \
+        'StudyInstanceUID (0020|000d) changed on write — GDCM regenerated it ' \
+        'instead of preserving the original (regression of the issue #1470 fix)'
+    assert image_back.metadata[series_instance_uid_tag] == original_series, \
+        'SeriesInstanceUID (0020|000e) changed on write — GDCM regenerated it ' \
+        'instead of preserving the original (regression of the issue #1470 fix)'

--- a/packages/image-io/typescript/test/node/gdcm-preserve-uid-test.js
+++ b/packages/image-io/typescript/test/node/gdcm-preserve-uid-test.js
@@ -1,0 +1,86 @@
+import test from 'ava'
+import path from 'path'
+
+import { gdcmReadImageNode, gdcmWriteImageNode } from '../../dist/index-node.js'
+
+import { testInputPath, testOutputPath } from './common.js'
+
+// Authoritative regression test for issue #1470: itk::GDCMImageIO regenerates the
+// StudyInstanceUID (0020|000d) and SeriesInstanceUID (0020|000e) on write unless
+// KeepOriginalUID is set. The fix in write-image.cxx enables SetKeepOriginalUID(true)
+// when the input metadata already carries these tags. This test reads a DICOM with
+// known Study/Series UIDs, writes it back through the fixed gdcm-write wasm, reads it
+// again, and asserts the UIDs are byte-for-byte identical across the round-trip.
+// Refs: https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1470
+
+const testInputFilePath = path.join(
+  testInputPath,
+  '1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.100.0.dcm'
+)
+const testOutputFilePath = path.join(testOutputPath, 'gdcm-preserve-uid.dcm')
+
+const studyInstanceUIDTag = '0020|000d'
+const seriesInstanceUIDTag = '0020|000e'
+
+// Valid, all-numeric sentinel UIDs used only if the sample happens not to carry the
+// tags. The DICOM UI value representation allows digits and dots only (no letters), so
+// these must stay numeric or GDCM would reject/regenerate them and defeat the fallback.
+const sentinelStudyUID = '1.2.826.0.1.3680043.9.7.1470.1'
+const sentinelSeriesUID = '1.2.826.0.1.3680043.9.7.1470.2'
+
+test('Preserves Study/Series Instance UIDs across a DICOM write->read round-trip', async t => {
+  const { couldRead, image } = await gdcmReadImageNode(testInputFilePath)
+  t.true(couldRead, 'could read the input DICOM')
+
+  // Capture the UIDs carried by the source image metadata (image.metadata is a Map).
+  let originalStudyUid = image.metadata.get(studyInstanceUIDTag)
+  let originalSeriesUid = image.metadata.get(seriesInstanceUIDTag)
+
+  // Defensive fallback guarding the test's premise: preservation can only be exercised
+  // if there is a UID to preserve. If (and only if) the sample lacks a tag, set a known
+  // sentinel on the metadata Map before writing so the write still triggers the fix
+  // (which keys off the presence of 0020|000d / 0020|000e in the input metadata).
+  let usedSentinelStudy = false
+  let usedSentinelSeries = false
+  if (!originalStudyUid) {
+    originalStudyUid = sentinelStudyUID
+    image.metadata.set(studyInstanceUIDTag, originalStudyUid)
+    usedSentinelStudy = true
+  }
+  if (!originalSeriesUid) {
+    originalSeriesUid = sentinelSeriesUID
+    image.metadata.set(seriesInstanceUIDTag, originalSeriesUid)
+    usedSentinelSeries = true
+  }
+  if (usedSentinelStudy || usedSentinelSeries) {
+    t.log(
+      `Sample lacked a UID tag; used sentinel value(s): study=${usedSentinelStudy}, series=${usedSentinelSeries}`
+    )
+  }
+
+  // The premise: we must have non-empty UIDs to preserve (from the sample or the fallback).
+  t.truthy(originalStudyUid, 'a StudyInstanceUID (0020|000d) is present to preserve')
+  t.truthy(originalSeriesUid, 'a SeriesInstanceUID (0020|000e) is present to preserve')
+
+  // Write the image back out through the fixed gdcm-write wasm (uncompressed).
+  const useCompression = false
+  const { couldWrite } = await gdcmWriteImageNode(image, testOutputFilePath, { useCompression })
+  t.true(couldWrite, 'could write the DICOM')
+
+  // Read the freshly written file back.
+  const { couldRead: couldReadBack, image: imageBack } = await gdcmReadImageNode(testOutputFilePath)
+  t.true(couldReadBack, 'could read the written DICOM back')
+
+  // Core assertions: the UIDs must survive the round-trip byte-for-byte. A mismatch means
+  // GDCM regenerated the UID on write instead of preserving it (the pre-fix bug, #1470).
+  t.is(
+    imageBack.metadata.get(studyInstanceUIDTag),
+    originalStudyUid,
+    'StudyInstanceUID (0020|000d) changed on write — GDCM regenerated it instead of preserving the original (regression of the issue #1470 fix)'
+  )
+  t.is(
+    imageBack.metadata.get(seriesInstanceUIDTag),
+    originalSeriesUid,
+    'SeriesInstanceUID (0020|000e) changed on write — GDCM regenerated it instead of preserving the original (regression of the issue #1470 fix)'
+  )
+})

--- a/packages/image-io/write-image.cxx
+++ b/packages/image-io/write-image.cxx
@@ -63,6 +63,7 @@
 #  include "itkGEAdwImageIO.h"
 #elif IMAGE_IO_CLASS == 18
 #  include "itkGDCMImageIO.h"
+#  include "itkMetaDataDictionary.h"
 #elif IMAGE_IO_CLASS == 19
 #  include "itkScancoImageIO.h"
 #elif IMAGE_IO_CLASS == 20
@@ -130,6 +131,18 @@ writeImage(itk::wasm::InputImageIO &     inputImageIO,
     imageIO->SetDimensions(dim, inputImageIOBase->GetDimensions(dim));
   };
   imageIO->SetMetaDataDictionary(inputImageIOBase->GetMetaDataDictionary());
+#if IMAGE_IO_CLASS == 18
+  // Issue #1470: itk::GDCMImageIO regenerates the StudyInstanceUID (0020|000d) and
+  // SeriesInstanceUID (0020|000e) when writing DICOM because m_KeepOriginalUID defaults to
+  // false. When the input image metadata already carries a Study or Series Instance UID,
+  // preserve the original UIDs rather than generating new ones. The trigger is scoped to the
+  // Study/Series UID tags; no SOPInstanceUID (0008|0018) handling is added here.
+  const itk::MetaDataDictionary & inputMetaDataDictionary = inputImageIOBase->GetMetaDataDictionary();
+  if (inputMetaDataDictionary.HasKey("0020|000d") || inputMetaDataDictionary.HasKey("0020|000e"))
+  {
+    imageIO->SetKeepOriginalUID(true);
+  }
+#endif
   itk::ImageIORegion ioRegion(dimension);
   for (unsigned int dim = 0; dim < dimension; ++dim)
   {


### PR DESCRIPTION
## Summary

Fixes [#1470](https://github.com/InsightSoftwareConsortium/ITK-Wasm/issues/1470): when writing DICOM through `itk::GDCMImageIO`, the `StudyInstanceUID` (`0020|000d`) and `SeriesInstanceUID` (`0020|000e`) were being regenerated instead of preserved, so a simple read → write round-trip silently changed the identifiers that tie an image back to its study and series.

This PR preserves the original Study/Series Instance UIDs on write, and adds regression tests in both the Node/TypeScript and Python/WASI test suites.

## Why

`itk::GDCMImageIO` defaults `m_KeepOriginalUID` to `false`, which causes GDCM to mint brand-new Study/Series UIDs every time an image is written. For any workflow that reads an existing DICOM, does something to it, and writes it back, this breaks referential integrity — the output no longer belongs to the same study/series as the input, even though nothing about that grouping was meant to change.

## What changed

- **`packages/image-io/write-image.cxx`** — the core fix. For the GDCM writer (`IMAGE_IO_CLASS == 18`), if the input image's metadata dictionary already carries a Study (`0020|000d`) or Series (`0020|000e`) Instance UID, call `imageIO->SetKeepOriginalUID(true)` so GDCM writes the original UIDs through unchanged. Also adds the `itkMetaDataDictionary.h` include needed to inspect the dictionary.
- **`packages/image-io/typescript/test/node/gdcm-preserve-uid-test.js`** — new Node round-trip regression test: reads a sample DICOM, writes it via the fixed `gdcm-write` wasm, reads it back, and asserts both UIDs are byte-for-byte identical.
- **`packages/image-io/python/itkwasm-image-io-wasi/tests/test_gdcm_preserve_uid.py`** — Python/WASI mirror of the Node test, with an explicit precondition check that the sample actually carries both UID tags (so the round-trip assertion can't pass vacuously).
- **`packages/image-io/python/itkwasm-image-io-emscripten/.../js_package.py`** — regenerated Python binding artifact from the WASI/emscripten rebuild of the fixed module.

## Implementation details

- The fix is **scoped narrowly**: it only triggers when the source metadata actually contains a Study or Series Instance UID, so images without those tags are unaffected and behavior is otherwise unchanged.
- It is **guarded to the GDCM writer only** (`#if IMAGE_IO_CLASS == 18`); no other `ImageIO` backends are touched.
- **No `SOPInstanceUID` (`0008|0018`) handling is added.** The per-instance UID is intentionally left to GDCM's default behavior; this change is limited to preserving the study/series grouping.

## Test plan

- [ ] Node: `gdcm-preserve-uid-test.js` passes (read → write → read, UIDs unchanged)
- [ ] Python/WASI: `test_gdcm_preserve_uid.py` precondition + round-trip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
